### PR TITLE
Fix first Pages deploy: auto-enable GitHub Pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,14 @@ jobs:
       - name: Render site
         run: quarto render
 
+      - name: Configure GitHub Pages
+        if: github.event_name != 'pull_request'
+        uses: actions/configure-pages@v5
+        with:
+          # Create/enable the Pages site (source: GitHub Actions) if it
+          # doesn't exist yet, so first deploys don't 404.
+          enablement: true
+
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
## Summary

The post-merge deploy of #1 failed at `actions/deploy-pages` with:

```
Error: Failed to create deployment (status: 404) ...
Ensure GitHub Pages has been enabled: https://github.com/noahweidig/portfolio/settings/pages
```

The repo has no Pages site yet. This adds `actions/configure-pages@v5` with `enablement: true` before the artifact upload, which creates the Pages site (build type: GitHub Actions) on first run. The step is skipped on PR render-only checks.

**Fallback:** if `GITHUB_TOKEN` lacks permission to create the site, enable it once manually at Settings → Pages → Source: **GitHub Actions**, then re-run the Publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKtYvRJ1XCS8ksp5TwAFWc

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKtYvRJ1XCS8ksp5TwAFWc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated publishing to configure and enable the GitHub Pages site during initial deployments.
  * Pull request workflows continue to avoid changing Pages configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->