### PR TITLE
Remove nav social icons, footer nav links, thin avatar ring

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -46,11 +46,6 @@ website:
     right:
       - text: "Book Now →"
         href: "https://cal.com/noah-weidig/meet"
-    tools:
-      - icon: github
-        href: "https://github.com/noahweidig/"
-      - icon: linkedin
-        href: "https://www.linkedin.com/in/noahweidig/"
   search:
     location: navbar
     type: overlay
@@ -58,17 +53,6 @@ website:
     border: false
     left: |
       © 2026 Noah Weidig.
-    center:
-      - text: Experience
-        href: index.qmd#experience
-      - text: Projects
-        href: index.qmd#projects
-      - text: Publications
-        href: publications/index.qmd
-      - text: Blog
-        href: blog/index.qmd
-      - text: FAQ
-        href: index.qmd#faq
     right:
       - icon: linkedin
         href: "https://www.linkedin.com/in/noahweidig/"

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -96,8 +96,8 @@ body {
   height: 9.5rem;
   border-radius: 50%;
   object-fit: cover;
-  border: 4px solid var(--nw-border);
-  box-shadow: 0 0 0 6px rgba(99, 102, 241, 0.25);
+  border: 2px solid var(--nw-border);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.25);
   margin-bottom: 1.5rem;
 }
 


### PR DESCRIPTION
## Summary
- Removed the GitHub/LinkedIn icons from the navbar (`tools` entry in `_quarto.yml`)
- Removed the "Experience / Projects / Publications / Blog / FAQ" text links from the footer center section
- Reduced the profile picture ring thickness (border 4px→2px, box-shadow ring 6px→3px) in `assets/theme.scss`

## Test plan
- [ ] Render site with Quarto and visually confirm navbar has no icons
- [ ] Confirm footer only shows copyright text and right-side social icons
- [ ] Confirm avatar ring appears thinner on hero section


---
_Generated by [Claude Code](https://claude.ai/code/session_01SiEcrMbiF2Jtzeh2NufUZ5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced the avatar border thickness and shadow for a lighter visual appearance.
  * Simplified the page footer by removing center navigation links while retaining copyright information and search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->