### PR TITLE
Fix project and research area cards overflowing at narrow widths

### DIFF
--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -265,7 +265,7 @@ body {
 .nw-grid {
   display: grid;
   gap: 1.5rem;
-  grid-template-columns: repeat(auto-fill, minmax(19rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(19rem, 100%), 1fr));
 }
 
 .nw-card {
@@ -337,7 +337,7 @@ body {
 .nw-projects.quarto-listing {
   display: grid;
   gap: 1.5rem;
-  grid-template-columns: repeat(auto-fill, minmax(19rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(19rem, 100%), 1fr));
 }
 
 .nw-proj-card {


### PR DESCRIPTION
## Summary
- The "Research Areas" (`.nw-grid`) and "Featured Projects" (`.nw-projects.quarto-listing`) card grids used `grid-template-columns: repeat(auto-fill, minmax(19rem, 1fr))`, which forces a minimum track width of 19rem regardless of the container's actual width.
- On narrow viewports (roughly under ~19rem plus the section's horizontal padding), the grid track couldn't shrink to fit, so the grid overflowed its container and pushed extra empty space onto the right side of the page.
- Wrapped the minimum in `min(19rem, 100%)` for both grids so tracks shrink to fit the available width instead of forcing a fixed minimum.

## Test plan
- [x] Reproduced the overflow behavior in a standalone HTML/CSS test at 320px viewport width using Playwright/Chromium: old rule produced a 304px-wide grid track against a 272px container (32px overflow); new rule produced a 272px-wide track (no overflow).
- [ ] Visually spot-check the live site's Research Areas and Featured Projects sections at narrow widths (Quarto isn't available in this sandbox to render the full site).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RwJry7XieZtNv8HaKmTnLA)_