### PR TITLE
Hero, navbar, and footer polish: eyebrow heading, SVG icons, mobile menu fixes

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -14,6 +14,7 @@ project:
     - web-app-manifest-512x512.png
     - "uploads/**"
     - "assets/media/**"
+    - assets/nw-nav.js
 
 website:
   title: "Noah Weidig"
@@ -54,19 +55,19 @@ website:
     left: |
       © 2026 Noah Weidig.
     right:
-      - icon: linkedin
+      - text: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><path d="M8 11v5"/><path d="M8 8v.01"/><path d="M12 16v-5"/><path d="M16 16v-3a2 2 0 0 0 -4 0"/></svg>'
         href: "https://www.linkedin.com/in/noahweidig/"
         aria-label: LinkedIn
-      - icon: github
+      - text: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-4.3 1.4 -4.3 -2.5 -6 -3m12 5v-3.5c0 -1 .1 -1.4 -.5 -2c2.8 -.3 5.5 -1.4 5.5 -6.1a4.6 4.6 0 0 0 -1.3 -3.2a4.2 4.2 0 0 0 -.1 -3.2s-1.1 -.3 -3.5 1.3a12.3 12.3 0 0 0 -6.2 0c-2.4 -1.6 -3.5 -1.3 -3.5 -1.3a4.2 4.2 0 0 0 -.1 3.2a4.6 4.6 0 0 0 -1.3 3.2c0 4.6 2.7 5.7 5.5 6.1c-.6 .6 -.6 1.2 -.5 2v3.5"/></svg>'
         href: "https://github.com/noahweidig/"
         aria-label: GitHub
-      - icon: mortarboard-fill
+      - text: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 9l-10 -4l-10 4l10 4l10 -4v6"/><path d="M6 10.6v5.4a6 3 0 0 0 12 0v-5.4"/></svg>'
         href: "https://scholar.google.com/citations?hl=en&user=Ml95eTwAAAAJ"
         aria-label: Google Scholar
-      - icon: person-badge
+      - text: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M9 10v6"/><path d="M9 7v.01"/><path d="M12.5 16v-6h2a3 3 0 0 1 0 6z"/></svg>'
         href: "https://orcid.org/0000-0003-1205-3209"
         aria-label: ORCID
-      - icon: envelope-fill
+      - text: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 7l9 6l9 -6"/></svg>'
         href: "mailto:noah@noahweidig.com"
         aria-label: Email
 
@@ -78,6 +79,9 @@ format:
       dark: [cosmo, assets/theme.scss, assets/theme-dark.scss]
       light: [cosmo, assets/theme.scss, assets/theme-light.scss]
     css: assets/site.css
+    include-after-body:
+      - text: |
+          <script src="/assets/nw-nav.js"></script>
     toc: false
     anchor-sections: false
     link-external-newwindow: true

--- a/assets/nw-nav.js
+++ b/assets/nw-nav.js
@@ -1,0 +1,10 @@
+// The theme toggle is an <a href="">; stop it from navigating (which jumps to the top).
+document.addEventListener(
+  "click",
+  function (e) {
+    if (e.target.closest && e.target.closest(".quarto-color-scheme-toggle")) {
+      e.preventDefault();
+    }
+  },
+  true
+);

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -135,6 +135,15 @@ body {
   margin: 0 0 0.5rem;
 }
 
+#hero h1 .nw-hi {
+  display: block;
+  font-size: 1rem;
+  font-weight: 400;
+  letter-spacing: 0.02em;
+  color: var(--nw-muted);
+  margin-bottom: 0.5rem;
+}
+
 #hero h1 .nw-name {
   background: var(--nw-grad);
   -webkit-background-clip: text;
@@ -217,6 +226,11 @@ body {
   font-weight: 600;
   text-decoration: none !important;
   transition: transform 0.15s, box-shadow 0.15s;
+}
+
+.nw-btn svg {
+  width: 1.1em;
+  height: 1.1em;
 }
 
 .nw-btn:hover {
@@ -806,4 +820,32 @@ body {
 @media (max-width: 640px) {
   .nw-post-date { flex-basis: 5.5rem; }
   .nw-section { padding: 3rem 0; }
+}
+
+/* mobile: overlay the expanded hamburger menu instead of pushing content down */
+@media (max-width: 991.98px) {
+  .navbar .navbar-collapse {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: var(--nw-bg);
+    border-bottom: 1px solid var(--nw-border);
+    padding: 0.5rem 1rem 1rem;
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
+  }
+}
+
+/* very narrow screens: shrink the site title so it isn't cut off */
+@media (max-width: 400px) {
+  .navbar .navbar-title {
+    font-size: 0.85rem;
+  }
+}
+
+/* footer social icons (inline SVGs matching the hero) */
+.nav-footer a svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  vertical-align: -0.25em;
 }

--- a/index.qmd
+++ b/index.qmd
@@ -44,7 +44,7 @@ include-after-body:
 <section id="hero">
   <img class="nw-avatar" src="assets/media/authors/me.webp" alt="Noah Weidig">
   <div><span class="nw-status">Open to opportunities</span></div>
-  <h1>Hi, I'm <span class="nw-name">Noah Weidig</span></h1>
+  <h1><span class="nw-hi">— Hi, I'm —</span><span class="nw-name">Noah Weidig</span></h1>
   <div class="nw-role">GIS Analyst • Data Scientist</div>
   <div class="nw-type">I build <span class="nw-typed" data-strings='["geospatial analyses","remote sensing workflows","data-driven insights","GIS applications"]'></span><span class="nw-caret">&nbsp;</span></div>
   <div class="nw-socials">
@@ -55,7 +55,7 @@ include-after-body:
   </div>
   <div class="nw-btns">
     <a class="nw-btn nw-btn-primary" href="#projects">View My Work ↓</a>
-    <a class="nw-btn nw-btn-ghost" href="#contact">Get In Touch ✉</a>
+    <a class="nw-btn nw-btn-ghost" href="#contact">Get In Touch <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 7l9 6l9 -6"/></svg></a>
   </div>
 </section>
 


### PR DESCRIPTION
## Changes

- **Hero heading**: "Hi, I'm" now sits on its own line above "Noah Weidig" as a small, non-bold eyebrow (`— Hi, I'm —` with space-padded em dashes, muted color).
- **Theme toggle scroll jump**: Quarto's light/dark toggle is an `<a href="">`, so clicking it navigated and pulled the page to the top. A new site-wide `assets/nw-nav.js` intercepts the click (capture phase) and calls `preventDefault()`; the toggle itself still works.
- **Get In Touch button**: replaced the ✉ emoji with an inline SVG envelope matching the hero's icon style, with `1.1em` sizing for button SVGs.
- **Mobile hamburger menu**: the expanded navbar collapse is now absolutely positioned as an overlay below the navbar (with themed background, border, and shadow) so it no longer pushes the page content down.
- **Narrow-width site title**: at ≤400px the navbar title shrinks to 0.85rem so it isn't cut off.
- **Footer icons**: the footer now uses the same inline SVG icons (LinkedIn, GitHub, Scholar, ORCID, plus the envelope) as the hero, replacing the Bootstrap icon set, with sizing CSS for `.nav-footer`.

## Notes

Quarto isn't installable in this environment (its release binaries are GitHub-hosted and blocked by the session proxy), so the site wasn't rendered here — `_quarto.yml` was validated for parseability instead. Worth a quick visual check of the rendered footer, since the SVG markup there relies on raw HTML passing through the footer `text:` fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTG7WUbJdXTTPFELDWYbor

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTG7WUbJdXTTPFELDWYbor)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the hero section with clearer heading styling and a refreshed contact button icon.
  * Added responsive navigation behavior for mobile and narrow screens.
  * Updated footer social links with consistent inline icons.

* **Bug Fixes**
  * Prevented the theme toggle from unexpectedly navigating to the top of the page.

* **Style**
  * Refined icon sizing, typography, spacing, and mobile navbar presentation for a more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->