### PR TITLE
Design refinements: whitespace, grid backdrop, topo footer, skills layout, giscus comments

### DIFF
--- a/_ejs/award-card.ejs
+++ b/_ejs/award-card.ejs
@@ -1,13 +1,1 @@
-<div class="nw-carousel">
-<% for (const item of items) { %>
-<a class="nw-award" href="<%- item.path %>">
-<figure>
-<% if (item.image) { %><img src="<%- item.image %>" alt="<%= item.title %>" loading="lazy"><% } %>
-<figcaption>
-<b><%= item.title %></b>
-<span><%= item.description || '' %></span>
-</figcaption>
-</figure>
-</a>
-<% } %>
-</div>
+<div class="nw-carousel"><% for (const item of items) { %><a class="nw-award" href="<%- item.path %>"><figure><% if (item.image) { %><img src="<%- item.image %>" alt="<%= item.title %>" loading="lazy"><% } %><figcaption><b><%= item.title %></b><span><%= item.description || '' %></span></figcaption></figure></a><% } %></div>

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -52,24 +52,57 @@ website:
     type: overlay
   page-footer:
     border: false
-    left: |
-      © 2026 Noah Weidig.
-    right:
-      - text: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><path d="M8 11v5"/><path d="M8 8v.01"/><path d="M12 16v-5"/><path d="M16 16v-3a2 2 0 0 0 -4 0"/></svg>'
-        href: "https://www.linkedin.com/in/noahweidig/"
-        aria-label: LinkedIn
-      - text: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-4.3 1.4 -4.3 -2.5 -6 -3m12 5v-3.5c0 -1 .1 -1.4 -.5 -2c2.8 -.3 5.5 -1.4 5.5 -6.1a4.6 4.6 0 0 0 -1.3 -3.2a4.2 4.2 0 0 0 -.1 -3.2s-1.1 -.3 -3.5 1.3a12.3 12.3 0 0 0 -6.2 0c-2.4 -1.6 -3.5 -1.3 -3.5 -1.3a4.2 4.2 0 0 0 -.1 3.2a4.6 4.6 0 0 0 -1.3 3.2c0 4.6 2.7 5.7 5.5 6.1c-.6 .6 -.6 1.2 -.5 2v3.5"/></svg>'
-        href: "https://github.com/noahweidig/"
-        aria-label: GitHub
-      - text: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 9l-10 -4l-10 4l10 4l10 -4v6"/><path d="M6 10.6v5.4a6 3 0 0 0 12 0v-5.4"/></svg>'
-        href: "https://scholar.google.com/citations?hl=en&user=Ml95eTwAAAAJ"
-        aria-label: Google Scholar
-      - text: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M9 10v6"/><path d="M9 7v.01"/><path d="M12.5 16v-6h2a3 3 0 0 1 0 6z"/></svg>'
-        href: "https://orcid.org/0000-0003-1205-3209"
-        aria-label: ORCID
-      - text: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 7l9 6l9 -6"/></svg>'
-        href: "mailto:noah@noahweidig.com"
-        aria-label: Email
+    center: |
+      <div class="nw-footer">
+      <div class="nw-footer-grid">
+      <div class="nw-footer-brand">
+      <a class="nw-footer-logo" href="/"><img src="/assets/media/icon.svg" alt="">Noah Weidig</a>
+      <p>GIS Analyst • Data Scientist</p>
+      <div class="nw-footer-socials">
+      <a href="https://www.linkedin.com/in/noahweidig/" aria-label="LinkedIn" target="_blank" rel="noopener"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><path d="M8 11v5"/><path d="M8 8v.01"/><path d="M12 16v-5"/><path d="M16 16v-3a2 2 0 0 0 -4 0"/></svg></a>
+      <a href="https://github.com/noahweidig/" aria-label="GitHub" target="_blank" rel="noopener"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-4.3 1.4 -4.3 -2.5 -6 -3m12 5v-3.5c0 -1 .1 -1.4 -.5 -2c2.8 -.3 5.5 -1.4 5.5 -6.1a4.6 4.6 0 0 0 -1.3 -3.2a4.2 4.2 0 0 0 -.1 -3.2s-1.1 -.3 -3.5 1.3a12.3 12.3 0 0 0 -6.2 0c-2.4 -1.6 -3.5 -1.3 -3.5 -1.3a4.2 4.2 0 0 0 -.1 3.2a4.6 4.6 0 0 0 -1.3 3.2c0 4.6 2.7 5.7 5.5 6.1c-.6 .6 -.6 1.2 -.5 2v3.5"/></svg></a>
+      <a href="https://scholar.google.com/citations?hl=en&user=Ml95eTwAAAAJ" aria-label="Google Scholar" target="_blank" rel="noopener"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 9l-10 -4l-10 4l10 4l10 -4v6"/><path d="M6 10.6v5.4a6 3 0 0 0 12 0v-5.4"/></svg></a>
+      <a href="https://orcid.org/0000-0003-1205-3209" aria-label="ORCID" target="_blank" rel="noopener"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M9 10v6"/><path d="M9 7v.01"/><path d="M12.5 16v-6h2a3 3 0 0 1 0 6z"/></svg></a>
+      </div>
+      </div>
+      <div class="nw-footer-col">
+      <h3>About</h3>
+      <ul>
+      <li><a href="/#experience"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="7" width="18" height="13" rx="2"/><path d="M8 7V5a2 2 0 0 1 2 -2h4a2 2 0 0 1 2 2v2"/><path d="M12 12v.01"/><path d="M3 13a20 20 0 0 0 18 0"/></svg>Experience</a></li>
+      <li><a href="/#education"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21h18"/><path d="M3 10h18"/><path d="M5 6l7 -3l7 3"/><path d="M4 10v11"/><path d="M20 10v11"/><path d="M8 14v3"/><path d="M12 14v3"/><path d="M16 14v3"/></svg>Education</a></li>
+      <li><a href="/#skills"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4l4 4"/><path d="M17 8l4 4l-4 4"/><path d="M14 4l-4 16"/></svg>Skills</a></li>
+      </ul>
+      </div>
+      <div class="nw-footer-col">
+      <h3>Work</h3>
+      <ul>
+      <li><a href="/#projects"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 13a8 8 0 0 1 7 7a6 6 0 0 0 3 -5a9 9 0 0 0 6 -8a3 3 0 0 0 -3 -3a9 9 0 0 0 -8 6a6 6 0 0 0 -5 3"/><path d="M7 14a6 6 0 0 0 -3 6a6 6 0 0 0 6 -3"/><circle cx="15" cy="9" r="1"/></svg>Projects</a></li>
+      <li><a href="https://noahweidig.com/geo-portfolio"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7l6 -3l6 3l6 -3v13l-6 3l-6 -3l-6 3z"/><path d="M9 4v13"/><path d="M15 7v13"/></svg>Geo Portfolio</a></li>
+      <li><a href="/#awards"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 21h8"/><path d="M12 17v4"/><path d="M7 4h10v6a5 5 0 0 1 -10 0z"/><path d="M7 6h-2a2 2 0 0 0 0 4h2"/><path d="M17 6h2a2 2 0 0 1 0 4h-2"/></svg>Awards</a></li>
+      </ul>
+      </div>
+      <div class="nw-footer-col">
+      <h3>Resources</h3>
+      <ul>
+      <li><a href="/#publications"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3v4a1 1 0 0 0 1 1h4"/><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z"/><path d="M9 9h1"/><path d="M9 13h6"/><path d="M9 17h6"/></svg>Publications</a></li>
+      <li><a href="/#blog"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 20h4l10.5 -10.5a2.83 2.83 0 0 0 -4 -4l-10.5 10.5v4"/><path d="M13.5 6.5l4 4"/></svg>Blog</a></li>
+      <li><a href="/#faq"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 17v.01"/><path d="M12 13.5a1.5 1.5 0 0 1 1 -1.5a2.6 2.6 0 1 0 -3 -4"/></svg>FAQ</a></li>
+      </ul>
+      </div>
+      <div class="nw-footer-col">
+      <h3>Connect</h3>
+      <ul>
+      <li><a href="mailto:noah@noahweidig.com"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 7l9 6l9 -6"/></svg>Email</a></li>
+      <li><a href="/#contact"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 9h8"/><path d="M8 13h6"/><path d="M18 4a3 3 0 0 1 3 3v8a3 3 0 0 1 -3 3h-5l-5 3v-3h-2a3 3 0 0 1 -3 -3v-8a3 3 0 0 1 3 -3h12z"/></svg>Contact</a></li>
+      <li><a href="https://cal.com/noah-weidig/meet" target="_blank" rel="noopener"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="16" rx="2"/><path d="M16 3v4"/><path d="M8 3v4"/><path d="M4 11h16"/><path d="M11 15h1"/><path d="M12 15v3"/></svg>Book a Call</a></li>
+      </ul>
+      </div>
+      </div>
+      <div class="nw-footer-bottom">
+      <div>© 2026 Noah Weidig.</div>
+      <div>All Rights Reserved.</div>
+      </div>
+      </div>
 
 format:
   html:

--- a/assets/nw-nav.js
+++ b/assets/nw-nav.js
@@ -8,3 +8,39 @@ document.addEventListener(
   },
   true
 );
+
+// Subtle back-to-top button, shown after scrolling down a bit.
+(function () {
+  var btn = document.createElement("button");
+  btn.className = "nw-top";
+  btn.type = "button";
+  btn.setAttribute("aria-label", "Back to top");
+  btn.innerHTML =
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5"/><path d="M5 12l7-7 7 7"/></svg>';
+  btn.addEventListener("click", function () {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  });
+  document.body.appendChild(btn);
+  var onScroll = function () {
+    btn.classList.toggle("show", window.scrollY > 600);
+  };
+  window.addEventListener("scroll", onScroll, { passive: true });
+  onScroll();
+})();
+
+// Project/award detail pages: surface the page's featured image below the title.
+(function () {
+  if (!/\/(projects|awards)\/[^/]+\/(index\.html)?$/.test(location.pathname)) return;
+  var meta = document.querySelector('meta[property="og:image"]');
+  var header = document.getElementById("title-block-header");
+  if (!meta || !header || document.querySelector(".nw-detail-hero")) return;
+  var img = document.createElement("img");
+  try {
+    img.src = new URL(meta.content, location.href).pathname;
+  } catch (e) {
+    img.src = meta.content;
+  }
+  img.alt = "";
+  img.className = "nw-detail-hero";
+  header.insertAdjacentElement("afterend", img);
+})();

--- a/assets/site.css
+++ b/assets/site.css
@@ -7,3 +7,325 @@ html {
 .page-layout-custom main {
   padding: 0;
 }
+
+/* ============ global grid-line backdrop (everything except the footer) ============ */
+body {
+  background-image:
+    linear-gradient(var(--nw-grid-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--nw-grid-line) 1px, transparent 1px);
+  background-size: 3.5rem 3.5rem;
+}
+
+/* sections sit transparent so the grid shows through; no gray alt bands */
+.nw-alt {
+  background: transparent;
+}
+
+#hero {
+  background: radial-gradient(60rem 30rem at 50% -10%, var(--nw-hero-glow), transparent 70%);
+}
+
+/* ============ premium whitespace between sections ============ */
+.nw-section {
+  padding: 6rem 0;
+}
+
+#hero {
+  padding-top: 7.5rem;
+  padding-bottom: 5rem;
+}
+
+@media (max-width: 640px) {
+  .nw-section {
+    padding: 3.5rem 0;
+  }
+}
+
+/* ============ hero name: plain fg color, not gradient ============ */
+#hero h1 .nw-name {
+  background: none;
+  -webkit-background-clip: initial;
+  background-clip: initial;
+  -webkit-text-fill-color: currentColor;
+  color: var(--nw-fg);
+}
+
+/* ============ navbar Book Now: never wrap; hide when space is tight ============ */
+.navbar .navbar-nav .nav-item a[href*="cal.com"] {
+  white-space: nowrap;
+}
+
+@media (min-width: 992px) and (max-width: 1249.98px) {
+  .navbar .navbar-nav .nav-item:has(> a[href*="cal.com"]) {
+    display: none;
+  }
+}
+
+/* ============ stats: only 4x1, 2x2, or 1x4 ============ */
+#stats .nw-stats {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+@media (max-width: 860px) {
+  #stats .nw-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 430px) {
+  #stats .nw-stats {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ============ tech stack: single column, larger items ============ */
+.nw-stack {
+  grid-template-columns: 1fr;
+  max-width: 60rem;
+  margin: 0 auto;
+  gap: 1.25rem;
+}
+
+.nw-stack-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem 2.75rem;
+}
+
+.nw-stack-item {
+  font-size: 0.95rem;
+  gap: 0.6rem;
+}
+
+.nw-stack-item img {
+  width: 3.25rem;
+  height: 3.25rem;
+}
+
+@media (min-width: 768px) {
+  .nw-stack-cat {
+    display: grid;
+    grid-template-columns: 10rem 1fr;
+    align-items: center;
+    padding: 1.75rem 2rem;
+  }
+
+  .nw-stack-cat h3 {
+    margin: 0;
+  }
+}
+
+/* ============ map: match the contact / CTA container width ============ */
+#map .nw-map {
+  max-width: 52rem;
+  margin: 0 auto;
+}
+
+/* ============ consistent side margins on listing pages ============ */
+.page-layout-full main.content {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4.5rem;
+}
+
+/* ============ awards grid cleanup ============ */
+.nw-carousel {
+  grid-template-columns: repeat(auto-fill, minmax(min(16rem, 100%), 1fr));
+  align-items: start;
+}
+
+.nw-carousel > p,
+.nw-projects > p,
+.nw-cites > p,
+.nw-posts > p {
+  display: none;
+}
+
+/* ============ detail pages: hero image injected from page metadata ============ */
+img.nw-detail-hero {
+  width: 100%;
+  max-height: 24rem;
+  object-fit: cover;
+  border-radius: 1rem;
+  border: 1px solid var(--nw-border);
+  margin-bottom: 1.5rem;
+}
+
+/* ============ back-to-top ============ */
+.nw-top {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 1030;
+  width: 2.75rem;
+  height: 2.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid var(--nw-border);
+  background: var(--nw-card);
+  color: var(--nw-muted);
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(0.5rem);
+  transition: opacity 0.25s, transform 0.25s, visibility 0.25s, border-color 0.15s, color 0.15s;
+}
+
+.nw-top.show {
+  opacity: 0.85;
+  visibility: visible;
+  transform: none;
+}
+
+.nw-top:hover {
+  opacity: 1;
+  border-color: var(--nw-primary);
+  color: var(--nw-primary);
+}
+
+.nw-top svg {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+/* ============ footer: topography backdrop + link columns ============ */
+.nav-footer {
+  position: relative;
+  background: var(--nw-footer-bg);
+  border-top: 1px solid var(--nw-border);
+  overflow: hidden;
+  padding: 0;
+}
+
+.nav-footer::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--nw-topo);
+  -webkit-mask: url(media/topography.svg) 0 0 / 37.5rem 37.5rem repeat;
+  mask: url(media/topography.svg) 0 0 / 37.5rem 37.5rem repeat;
+  pointer-events: none;
+}
+
+.nav-footer .nav-footer-center {
+  position: relative;
+  flex: 1 1 100%;
+  margin: 0;
+  text-align: left;
+}
+
+.nw-footer {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 4rem 1.5rem 2.5rem;
+}
+
+.nw-footer-grid {
+  display: grid;
+  grid-template-columns: 1.4fr repeat(4, 1fr);
+  gap: 2.5rem;
+}
+
+.nw-footer-brand .nw-footer-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 800;
+  font-size: 1.15rem;
+  color: var(--nw-primary);
+  text-decoration: none;
+}
+
+.nw-footer-brand .nw-footer-logo img {
+  height: 1.75rem;
+}
+
+.nw-footer-brand p {
+  color: var(--nw-muted);
+  font-size: 0.9rem;
+  margin: 0.75rem 0 1rem;
+  max-width: 14rem;
+}
+
+.nw-footer-socials {
+  display: flex;
+  gap: 0.9rem;
+}
+
+.nw-footer-socials a {
+  color: var(--nw-muted);
+  display: inline-flex;
+}
+
+.nw-footer-socials a:hover {
+  color: var(--nw-primary);
+}
+
+.nw-footer-socials svg {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.nw-footer-col h3 {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--nw-primary);
+  margin: 0 0 1rem;
+}
+
+.nw-footer-col ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.7rem;
+}
+
+.nw-footer-col a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--nw-muted);
+  font-size: 0.92rem;
+  text-decoration: none;
+}
+
+.nw-footer-col a:hover {
+  color: var(--nw-primary);
+}
+
+.nw-footer-col a svg {
+  width: 1.05rem;
+  height: 1.05rem;
+  flex: none;
+}
+
+.nw-footer-bottom {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 3.5rem;
+  color: var(--nw-muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 900px) {
+  .nw-footer-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .nw-footer-brand {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 480px) {
+  .nw-footer-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/assets/theme-dark.scss
+++ b/assets/theme-dark.scss
@@ -12,7 +12,7 @@ $input-bg: #13131a;
 
 :root {
   --nw-bg: #0a0a0f;
-  --nw-bg-alt: #0d0d12;
+  --nw-bg-alt: #0a0a0f;
   --nw-fg: #e5e7eb;
   --nw-muted: #9ca3af;
   --nw-card: #13131a;
@@ -23,6 +23,9 @@ $input-bg: #13131a;
   --nw-cta-via: #4338ca;
   --nw-cta-to: #7e22ce;
   --nw-cta-fg: #f5f3ff;
+  --nw-grid-line: rgba(229, 231, 235, 0.04);
+  --nw-topo: rgba(229, 231, 235, 0.07);
+  --nw-footer-bg: #0d0d12;
 }
 
 /* white logos pop on dark; keep institution marks legible */

--- a/assets/theme-light.scss
+++ b/assets/theme-light.scss
@@ -1,17 +1,17 @@
 /*-- scss:defaults --*/
 
-$body-bg: #fafafa;
+$body-bg: #ffffff;
 $body-color: #1f2937;
-$navbar-bg: rgba(250, 250, 250, 0.85);
+$navbar-bg: rgba(255, 255, 255, 0.85);
 $navbar-fg: #1f2937;
-$footer-bg: #f5f5f5;
+$footer-bg: #fafafa;
 $card-bg: #ffffff;
 
 /*-- scss:rules --*/
 
 :root {
-  --nw-bg: #fafafa;
-  --nw-bg-alt: #f5f5f5;
+  --nw-bg: #ffffff;
+  --nw-bg-alt: #ffffff;
   --nw-fg: #1f2937;
   --nw-muted: #6b7280;
   --nw-card: #ffffff;
@@ -22,4 +22,7 @@ $card-bg: #ffffff;
   --nw-cta-via: #e0e7ff;
   --nw-cta-to: #e9d5ff;
   --nw-cta-fg: #1e1b4b;
+  --nw-grid-line: rgba(31, 41, 55, 0.05);
+  --nw-topo: rgba(31, 41, 55, 0.08);
+  --nw-footer-bg: #fafafa;
 }

--- a/blog/_metadata.yml
+++ b/blog/_metadata.yml
@@ -1,0 +1,7 @@
+comments:
+  giscus:
+    repo: noahweidig/portfolio
+    category: General
+    mapping: pathname
+    reactions-enabled: true
+    loading: lazy

--- a/blog/index.qmd
+++ b/blog/index.qmd
@@ -3,6 +3,7 @@ title: "Blog"
 description: "Notes on science, data, maps, and the landscapes we live in."
 page-layout: full
 toc: false
+comments: false
 listing:
   id: all-posts
   contents: "*/index.qmd"

--- a/projects/chartifyr/index.qmd
+++ b/projects/chartifyr/index.qmd
@@ -5,7 +5,6 @@ description: Tutorials for Data Analysis & Viz
 categories:
 - R
 - Data Visualization
-- ggplot2
 image: featured.webp
 image-alt: ChartifyR tutorials for data analysis and visualization with ggplot2
 featured: true

--- a/projects/faststats/index.qmd
+++ b/projects/faststats/index.qmd
@@ -5,7 +5,7 @@ description: Fast, Client-side Analytics
 categories:
 - R
 - Data Visualization
-- plotly
+- Data Science
 image: featured.webp
 image-alt: FastStats browser-based analytics tool with data visualizations
 featured: true

--- a/projects/firer/index.qmd
+++ b/projects/firer/index.qmd
@@ -4,7 +4,6 @@ date: '2026-03-21'
 description: An R Package for U.S. Fire Data
 categories:
 - R
-- Package
 image: featured.webp
 image-alt: FireR R package for working with U.S. fire data
 featured: true

--- a/projects/imagestudio/index.qmd
+++ b/projects/imagestudio/index.qmd
@@ -3,7 +3,6 @@ title: Image Studio
 date: '2025-03-13'
 description: A Shiny App for Image Editing
 categories:
-- Personal
 - Creative
 image: featured.webp
 image-alt: Image Studio application for creative image editing and recoloring

--- a/projects/less/index.qmd
+++ b/projects/less/index.qmd
@@ -3,7 +3,7 @@ title: Less.
 date: '2025-03-13'
 description: A Personal Exploration of Minimalism
 categories:
-- Personal
+- Creative
 - Minimalism
 image: featured.webp
 image-alt: Less project exploring minimalism and personal philosophy

--- a/projects/maplab/index.qmd
+++ b/projects/maplab/index.qmd
@@ -3,7 +3,6 @@ title: MapLab
 date: '2026-03-24'
 description: A Simple GIS Software for Non-GIS Users
 categories:
-- GIS
 - Geospatial
 image: featured.webp
 image-alt: MapLab interface for basic geospatial analysis and mapping

--- a/projects/maps/index.qmd
+++ b/projects/maps/index.qmd
@@ -3,7 +3,6 @@ title: Map Explorer
 date: '2026-03-26'
 description: A Collection of Interactive Maps
 categories:
-- GIS
 - Geospatial
 image: featured.webp
 image-alt: Map Explorer interface for interactive geospatial analysis

--- a/projects/quickplot/index.qmd
+++ b/projects/quickplot/index.qmd
@@ -5,7 +5,6 @@ description: A Shiny App for Data Viz with No Code
 categories:
 - R
 - Data Visualization
-- Package
 image: featured.webp
 image-alt: QuickPlot Shiny app for creating publication-ready data visualizations
 featured: true

--- a/projects/roads/index.qmd
+++ b/projects/roads/index.qmd
@@ -3,9 +3,8 @@ title: TIGER Roads
 date: '2026-03-21'
 description: US Census TIGER Roads in GEE
 categories:
-- GIS
-- Google Earth Engine
 - Geospatial
+- Google Earth Engine
 image: featured.webp
 image-alt: TIGER Roads dataset visualization in Google Earth Engine
 featured: true

--- a/projects/shelf/index.qmd
+++ b/projects/shelf/index.qmd
@@ -3,8 +3,7 @@ title: Shelf
 date: '2026-02-18'
 description: My Personal Reading Journal
 categories:
-- Reading
-- Books
+- Creative
 - Data Science
 image: featured.webp
 image-alt: 'Shelf: My Personal Reading Journal'

--- a/projects/wildfire/index.qmd
+++ b/projects/wildfire/index.qmd
@@ -3,9 +3,8 @@ title: Wildfire Risk
 date: '2025-01-05'
 description: Wildfire Risk Visualizer by State
 categories:
-- GIS
 - Geospatial
-- Wildfire
+- Fire
 image: featured.webp
 image-alt: Wildfire Risk Visualizer interface showing risk assessment across U.S.
   states

--- a/projects/wuirisk/index.qmd
+++ b/projects/wuirisk/index.qmd
@@ -3,9 +3,7 @@ title: WUI Wildfire Explorer
 date: '2026-03-22'
 description: A GEE App for Visualizing Risk
 categories:
-- Wildfire
-- Risk
-- GIS
+- Fire
 - Geospatial
 - Google Earth Engine
 image: featured.webp


### PR DESCRIPTION
## Summary

Site-wide design polish plus blog comments, verified with a full local Quarto render and light/dark screenshots at multiple widths.

### Layout & backgrounds
- Subtle theme-aware grid lines behind the whole site (light and dark variants via `--nw-grid-line`), everywhere except the footer
- Footer rebuilt as brand + About/Work/Resources/Connect link columns with social icons, `© …` left / `All Rights Reserved.` right, over a `topography.svg` backdrop rendered with a CSS mask so it adapts to both themes
- More whitespace between sections (`6rem` desktop, `3.5rem` mobile); gray alt-section bands removed — light mode is all white
- Consistent side margins: full-layout listing pages (awards, projects, publications, blog) now share the same 72rem/1.5rem container as the home sections

### Home page
- Hero name is plain black/white (theme fg) instead of the purple gradient
- Stats grid locked to 4×1 → 2×2 → 1×4 only
- Tech stack is single-column with larger icons/labels (category label beside items on desktop)
- Map constrained to the same width as the contact form / CTA card
- Navbar “Book Now” never wraps; it hides between 992–1250px instead

### Fixes
- Awards page grid cleaned up — EJS whitespace was producing empty `<p>` grid children (the checkerboard gaps)
- Project and award detail pages now show their featured image below the title
- Subtle theme-consistent back-to-top button after scrolling

### Content
- Tags retagged and deduped: ggplot2/Package→R, GIS→Geospatial, plotly→Data Science, Books/Reading/Personal→Creative, Risk/Wildfire→Fire

### Blog comments (giscus)
- `blog/_metadata.yml` enables giscus on all blog posts (disabled on the blog index). **Setup required:** enable GitHub Discussions on this repo (with a “General” category) and install the [giscus app](https://github.com/apps/giscus) on it — Quarto then resolves the repo/category IDs automatically at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnACxgnJi5LX8y3s2csEjg

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnACxgnJi5LX8y3s2csEjg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a redesigned footer with navigation links, social links, contact options, and a “Book a Call” link.
  - Added a back-to-top button with smooth scrolling.
  - Project and award detail pages now display featured images more prominently.
  - Enabled comments and reactions on blog posts.

- **Style**
  - Refreshed responsive layouts, typography, backgrounds, grids, footer, navigation, and theme colors.

- **Content**
  - Improved project categorization and featured project metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->