### PR TITLE
Dark map theming, UI fixes, giscus repo fix, and SEO improvements

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -5,6 +5,7 @@ project:
     - "*.qmd"
   resources:
     - CNAME
+    - robots.txt
     - favicon.ico
     - favicon.svg
     - favicon-96x96.png
@@ -117,9 +118,46 @@ format:
     toc: false
     anchor-sections: false
     link-external-newwindow: true
+    lang: en
     include-in-header:
       - text: |
           <meta name="google-site-verification" content="0ktlvQnqLH01fphPI1cDMDTuQSmCG7mHBQdovXQs2TQ">
+          <meta name="author" content="Noah Weidig">
+          <script type="application/ld+json">
+          {
+            "@context": "https://schema.org",
+            "@graph": [
+              {
+                "@type": "Person",
+                "@id": "https://noahweidig.com/#person",
+                "name": "Noah Weidig",
+                "url": "https://noahweidig.com/",
+                "image": "https://noahweidig.com/assets/media/authors/me.webp",
+                "jobTitle": "GIS Analyst & Data Scientist",
+                "email": "mailto:noah@noahweidig.com",
+                "alumniOf": [
+                  { "@type": "CollegeOrUniversity", "name": "University of Florida", "url": "https://www.ufl.edu/" },
+                  { "@type": "CollegeOrUniversity", "name": "Northern Kentucky University", "url": "https://www.nku.edu/" }
+                ],
+                "knowsAbout": ["GIS", "Remote Sensing", "Spatial Data Science", "Ecology", "Data Visualization", "Machine Learning"],
+                "sameAs": [
+                  "https://www.linkedin.com/in/noahweidig/",
+                  "https://github.com/noahweidig/",
+                  "https://scholar.google.com/citations?hl=en&user=Ml95eTwAAAAJ",
+                  "https://orcid.org/0000-0003-1205-3209"
+                ]
+              },
+              {
+                "@type": "WebSite",
+                "@id": "https://noahweidig.com/#website",
+                "url": "https://noahweidig.com/",
+                "name": "Noah Weidig",
+                "description": "Noah Weidig is an ecologist and GIS analyst specializing in geospatial data science, environmental modeling, and large-scale spatial analysis.",
+                "publisher": { "@id": "https://noahweidig.com/#person" }
+              }
+            ]
+          }
+          </script>
           <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96">
           <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
           <link rel="manifest" href="/site.webmanifest">

--- a/assets/site.css
+++ b/assets/site.css
@@ -89,7 +89,12 @@ body {
 .nw-stack-items {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 1.5rem 2.75rem;
+}
+
+.nw-stack-cat {
+  text-align: center;
 }
 
 .nw-stack-item {
@@ -107,6 +112,7 @@ body {
     display: grid;
     grid-template-columns: 10rem 1fr;
     align-items: center;
+    justify-items: center;
     padding: 1.75rem 2rem;
   }
 
@@ -154,10 +160,13 @@ body {
 }
 
 /* ============ detail pages: hero image injected from page metadata ============ */
+/* taller frame + contain so the full image is visible without cropping */
 img.nw-detail-hero {
   width: 100%;
-  max-height: 24rem;
-  object-fit: cover;
+  aspect-ratio: 4 / 3;
+  max-height: 38rem;
+  object-fit: contain;
+  background: var(--nw-card);
   border-radius: 1rem;
   border: 1px solid var(--nw-border);
   margin-bottom: 1.5rem;

--- a/assets/theme-dark.scss
+++ b/assets/theme-dark.scss
@@ -27,6 +27,7 @@ $input-bg: #13131a;
   --nw-topo: rgba(229, 231, 235, 0.07);
   --nw-footer-bg: #0d0d12;
   --nw-glass: rgba(10, 10, 15, 0.85);
+  --nw-glass-strong: rgba(10, 10, 15, 0.96);
 }
 
 /* solid mark renders black by default; flip to white on dark */
@@ -38,4 +39,41 @@ $input-bg: #13131a;
 /* white logos pop on dark; keep institution marks legible */
 .nw-marquee-track img {
   filter: brightness(0) invert(0.85);
+}
+
+/* black tech-stack marks (GitHub, Markdown, LaTeX, …) flip to white on dark;
+   hue-rotate keeps any colored parts close to their original hue */
+.nw-stack-item img.nw-inv {
+  filter: invert(1) hue-rotate(180deg);
+}
+
+/* Leaflet chrome ships light-only; restyle controls and popups for dark */
+#map .leaflet-container {
+  background: #0a0a0f;
+}
+
+#map .leaflet-control-zoom a {
+  background: #13131a;
+  color: #e5e7eb;
+  border-color: #26262f;
+}
+
+#map .leaflet-control-zoom a:hover {
+  background: #1d1d26;
+}
+
+#map .leaflet-control-attribution {
+  background: rgba(19, 19, 26, 0.85);
+  color: #9ca3af;
+}
+
+#map .leaflet-control-attribution a {
+  color: #c7d2fe;
+}
+
+#map .leaflet-popup-content-wrapper,
+#map .leaflet-popup-tip {
+  background: #13131a;
+  color: #e5e7eb;
+  box-shadow: 0 3px 14px rgba(0, 0, 0, 0.6);
 }

--- a/assets/theme-light.scss
+++ b/assets/theme-light.scss
@@ -26,6 +26,7 @@ $card-bg: #ffffff;
   --nw-topo: rgba(31, 41, 55, 0.08);
   --nw-footer-bg: #fafafa;
   --nw-glass: rgba(255, 255, 255, 0.85);
+  --nw-glass-strong: rgba(255, 255, 255, 0.96);
 }
 
 /* solid mark stays black on light */

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -864,8 +864,9 @@ body {
 /* ============ detail pages ============ */
 .nw-detail-hero img {
   width: 100%;
-  max-height: 24rem;
-  object-fit: cover;
+  aspect-ratio: 4 / 3;
+  max-height: 38rem;
+  object-fit: contain;
   border-radius: 1rem;
   margin-bottom: 1.5rem;
 }
@@ -894,12 +895,22 @@ body {
     top: 100%;
     left: 0;
     right: 0;
-    background: var(--nw-glass);
+    /* nested backdrop-filter inside the already-blurred navbar is unreliable,
+       so the dropdown needs a near-opaque glass tint to match the navbar */
+    background: var(--nw-glass-strong);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     border-bottom: 1px solid var(--nw-border);
     padding: 0.5rem 1rem 1rem;
     box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
+  }
+
+  /* Book Now pill: hug the text instead of stretching across the dropdown */
+  .navbar .navbar-nav .nav-item a[href*="cal.com"] {
+    display: inline-block;
+    width: fit-content;
+    margin-left: 0;
+    margin-top: 0.5rem;
   }
 }
 

--- a/blog/_metadata.yml
+++ b/blog/_metadata.yml
@@ -1,6 +1,6 @@
 comments:
   giscus:
-    repo: noahweidig/portfolio
+    repo: noahweidig/noahweidig.github.io
     category: General
     mapping: pathname
     reactions-enabled: true

--- a/index.qmd
+++ b/index.qmd
@@ -30,11 +30,23 @@ include-after-body:
       <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
       <script>
         var nwMap = L.map('nw-map', { scrollWheelZoom: false }).setView([29.6436, -82.3549], 15);
-        L.tileLayer('https://{s}.basemaps.cartocdn.com/' +
-          (document.documentElement.classList.contains('quarto-dark') ? 'dark_all' : 'rastertiles/voyager') +
-          '/{z}/{x}/{y}{r}.png', {
-          attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>'
-        }).addTo(nwMap);
+        var nwTiles = null;
+        var nwTileStyle = null;
+        function nwSyncMapTheme() {
+          var style = document.body.classList.contains('quarto-dark') ||
+            document.documentElement.classList.contains('quarto-dark')
+            ? 'dark_all' : 'rastertiles/voyager';
+          if (style === nwTileStyle) return;
+          nwTileStyle = style;
+          if (nwTiles) nwMap.removeLayer(nwTiles);
+          nwTiles = L.tileLayer('https://{s}.basemaps.cartocdn.com/' + style + '/{z}/{x}/{y}{r}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>'
+          }).addTo(nwMap);
+        }
+        nwSyncMapTheme();
+        var nwThemeWatcher = new MutationObserver(nwSyncMapTheme);
+        nwThemeWatcher.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+        nwThemeWatcher.observe(document.body, { attributes: true, attributeFilter: ['class'] });
         L.marker([29.6436, -82.3549]).addTo(nwMap)
           .bindPopup('<b>University of Florida</b><br>School of Forest, Fisheries and Geomatic Sciences');
       </script>
@@ -251,13 +263,13 @@ include-after-body:
     <div class="nw-timeline">
       <div class="nw-tl-item">
         <h3>Master of Science, Forest Resources &amp; Conservation</h3>
-        <div><span class="nw-tl-org">University of Florida</span></div>
+        <div><a class="nw-tl-org" href="https://www.ufl.edu/" target="_blank" rel="noopener">University of Florida</a></div>
         <div class="nw-tl-meta">Aug 2023 – Aug 2025</div>
         <p>Thesis: Large Wildfire Patterns in the WUI, 4.0 GPA</p>
       </div>
       <div class="nw-tl-item">
         <h3>Bachelor of Science, Biological Sciences</h3>
-        <div><span class="nw-tl-org">Northern Kentucky University</span></div>
+        <div><a class="nw-tl-org" href="https://www.nku.edu/" target="_blank" rel="noopener">Northern Kentucky University</a></div>
         <div class="nw-tl-meta">Aug 2018 – May 2022</div>
         <p>Ecology, Evolution, &amp; Organismal Track, 4.0 GPA</p>
       </div>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://noahweidig.com/sitemap.xml


### PR DESCRIPTION
## Summary

- **Dark-themed map**: the Leaflet map now picks the Carto dark basemap in dark mode and switches live when the theme is toggled (MutationObserver on the `quarto-dark` class). Leaflet zoom buttons, attribution bar, and marker popup are also restyled for dark.
- **Skills cards**: category labels and icon grids are now centered within each tech-stack card.
- **Project/award detail pages**: hero image frame is taller (4:3, up to 38rem) and uses `object-fit: contain`, so the whole image is visible without cropping.
- **Dark-mode icons**: GitHub, Markdown, and LaTeX (and other `.nw-inv`) stack icons invert to white on the dark background.
- **Education links**: University of Florida and Northern Kentucky University are now clickable links, matching the experience section.
- **Mobile navbar**: the dropdown now uses a near-opaque glass tint (`--nw-glass-strong`) so it matches the navbar's glassmorphic look (nested `backdrop-filter` inside the blurred navbar is unreliable, which made it look transparent); the Book Now pill wraps its own text instead of spanning the full dropdown width.
- **Giscus comments fix**: config pointed at `noahweidig/portfolio`; now points at `noahweidig/noahweidig.github.io`. Note: the [giscus app](https://github.com/apps/giscus) must be installed on this repo and Discussions enabled with a "General" category for comments to load.
- **SEO**: Quarto already generates `sitemap.xml` on every render (verified live) because `site-url` is set — no workflow change needed. Added `robots.txt` referencing the sitemap, `lang: en`, an author meta tag, and JSON-LD structured data (Person + WebSite schema) site-wide.

## Testing

- Live site checked: `sitemap.xml` already served, confirming Quarto generates it on each publish.
- Quarto could not be installed in this sandbox (GitHub release downloads blocked), so the render check relies on the PR's render-only CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P45vcqboPr3LyB2Xmay6Na

---
_Generated by [Claude Code](https://claude.ai/code/session_01P45vcqboPr3LyB2Xmay6Na)_