### PR TITLE
Replace purple with #0076DF; outline Book Now CTA; set stats number colors per theme

### DIFF
--- a/assets/theme-dark.scss
+++ b/assets/theme-dark.scss
@@ -18,16 +18,17 @@ $input-bg: #13131a;
   --nw-card: #13131a;
   --nw-border: #26262f;
   --nw-chip: #1d1d26;
-  --nw-hero-glow: rgba(99, 102, 241, 0.18);
-  --nw-cta-from: #4f46e5;
-  --nw-cta-via: #4338ca;
-  --nw-cta-to: #7e22ce;
-  --nw-cta-fg: #f5f3ff;
+  --nw-hero-glow: rgba(0, 118, 223, 0.18);
+  --nw-cta-from: #0076DF;
+  --nw-cta-via: #0076DF;
+  --nw-cta-to: #0076DF;
+  --nw-cta-fg: #ffffff;
   --nw-grid-line: rgba(229, 231, 235, 0.04);
   --nw-topo: rgba(229, 231, 235, 0.07);
   --nw-footer-bg: #0d0d12;
   --nw-glass: rgba(10, 10, 15, 0.85);
   --nw-glass-strong: rgba(10, 10, 15, 0.96);
+  --nw-stat-number: #ffffff;
 }
 
 /* solid mark renders black by default; flip to white on dark */
@@ -68,7 +69,7 @@ $input-bg: #13131a;
 }
 
 #map .leaflet-control-attribution a {
-  color: #c7d2fe;
+  color: #8fcaff;
 }
 
 #map .leaflet-popup-content-wrapper,

--- a/assets/theme-light.scss
+++ b/assets/theme-light.scss
@@ -17,16 +17,17 @@ $card-bg: #ffffff;
   --nw-card: #ffffff;
   --nw-border: #e5e7eb;
   --nw-chip: #eef2f7;
-  --nw-hero-glow: rgba(99, 102, 241, 0.12);
-  --nw-cta-from: #c7d2fe;
-  --nw-cta-via: #e0e7ff;
-  --nw-cta-to: #e9d5ff;
-  --nw-cta-fg: #1e1b4b;
+  --nw-hero-glow: rgba(0, 118, 223, 0.12);
+  --nw-cta-from: #d7ebff;
+  --nw-cta-via: #eaf5ff;
+  --nw-cta-to: #f2f8ff;
+  --nw-cta-fg: #003b70;
   --nw-grid-line: rgba(31, 41, 55, 0.05);
   --nw-topo: rgba(31, 41, 55, 0.08);
   --nw-footer-bg: #fafafa;
   --nw-glass: rgba(255, 255, 255, 0.85);
   --nw-glass-strong: rgba(255, 255, 255, 0.96);
+  --nw-stat-number: #000000;
 }
 
 /* solid mark stays black on light */

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -3,17 +3,17 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap');
 
 $font-family-sans-serif: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif !default;
-$primary: #6366f1 !default;
-$link-color: #6366f1 !default;
+$primary: #0076DF !default;
+$link-color: #0076DF !default;
 $border-radius: 0.5rem !default;
 $navbar-padding-y: 0.65rem !default;
 
 /*-- scss:rules --*/
 
 :root {
-  --nw-primary: #6366f1;
-  --nw-secondary: #a855f7;
-  --nw-grad: linear-gradient(135deg, #6366f1, #a855f7);
+  --nw-primary: #0076DF;
+  --nw-secondary: #0076DF;
+  --nw-grad: linear-gradient(135deg, #0076DF, #0076DF);
 }
 
 body {
@@ -36,12 +36,19 @@ body {
 
 /* "Book Now" CTA styled as a button */
 .navbar .navbar-nav .nav-item a[href*="cal.com"] {
-  background: var(--nw-grad);
-  color: #fff !important;
+  background: transparent;
+  color: var(--nw-primary) !important;
+  border: 1px solid var(--nw-primary);
   border-radius: 999px;
   padding: 0.4rem 1.1rem !important;
   font-weight: 600;
   margin-left: 0.5rem;
+  transition: background-color 0.15s, color 0.15s, transform 0.15s;
+}
+
+.navbar .navbar-nav .nav-item a[href*="cal.com"]:hover {
+  background: var(--nw-primary);
+  color: #fff !important;
 }
 
 /* ============ shared section scaffolding ============ */
@@ -98,7 +105,7 @@ body {
   border-radius: 50%;
   object-fit: cover;
   border: 2px solid var(--nw-border);
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.25);
+  box-shadow: 0 0 0 3px rgba(0, 118, 223, 0.25);
   margin-bottom: 1.5rem;
 }
 
@@ -146,10 +153,7 @@ body {
 }
 
 #hero h1 .nw-name {
-  background: var(--nw-grad);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: var(--nw-fg);
 }
 
 #hero .nw-role {
@@ -243,7 +247,7 @@ body {
 .nw-btn-primary {
   background: var(--nw-grad);
   color: #fff !important;
-  box-shadow: 0 8px 24px rgba(99, 102, 241, 0.35);
+  box-shadow: 0 8px 24px rgba(0, 118, 223, 0.35);
 }
 
 .nw-btn-ghost {
@@ -281,10 +285,7 @@ body {
   display: block;
   font-size: 2.4rem;
   font-weight: 800;
-  background: var(--nw-grad);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: var(--nw-stat-number);
 }
 
 #stats .nw-stat span {
@@ -359,8 +360,8 @@ body {
 /* gradient icon tiles */
 .g-emerald { background: linear-gradient(135deg, #34d399, #14b8a6); }
 .g-amber   { background: linear-gradient(135deg, #fbbf24, #f97316); }
-.g-sky     { background: linear-gradient(135deg, #38bdf8, #6366f1); }
-.g-fuchsia { background: linear-gradient(135deg, #e879f9, #a855f7); }
+.g-sky     { background: linear-gradient(135deg, #38bdf8, #0076DF); }
+.g-fuchsia { background: linear-gradient(135deg, #38bdf8, #0076DF); }
 .g-lime    { background: linear-gradient(135deg, #a3e635, #16a34a); }
 .g-rose    { background: linear-gradient(135deg, #fb7185, #ef4444); }
 


### PR DESCRIPTION
### Motivation
- Update the site accent color from the original purple palette to a specific blue (`#0076DF`) and ensure CTAs and stat numbers remain legible in both light and dark themes.
- Make the navbar "Book Now" CTA outlined by default and fill with the blue on hover while preserving filled primary buttons with white text.

### Description
- Replaced primary/link/gradient tokens and related glow/shadow values with `#0076DF` in `assets/theme.scss` and adjusted dependent styles (gradients, box-shadows, and tile gradients).
- Converted the navbar Cal.com link rule to an outlined button (`background: transparent; border: 1px solid var(--nw-primary)`) and added a hover state that fills it with the blue and switches text to white via `.navbar .navbar-nav .nav-item a[href*="cal.com"]` and `:hover` rules in `assets/theme.scss`.
- Introduced the `--nw-stat-number` CSS variable and wired `#stats .nw-stat b` to use it, then set `--nw-stat-number` to `#000000` in `assets/theme-light.scss` and `#ffffff` in `assets/theme-dark.scss` so stats read black on light and white on dark.
- Updated a few supporting tokens and small UI touches (hero avatar glow, primary button shadows, and icon tile gradients) to the blue palette across `assets/theme.scss`, `assets/theme-light.scss`, and `assets/theme-dark.scss`.

### Testing
- Ran `git diff --check` with no reported style errors.
- Attempted `quarto render` but the Quarto CLI is not installed in the environment so a local site build could not be run; code changes were committed for review instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58f191a3a88320a2adefa2105c1484)