### PR TITLE
Center mobile hamburger menu and hide navbar logo when expanded

### DIFF
--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -891,6 +891,16 @@ body {
 /* mobile: overlay the expanded hamburger menu instead of pushing content down;
    same glassmorphic treatment as the navbar itself */
 @media (max-width: 991.98px) {
+  /* Keep every link in the expanded hamburger menu centered, including the CTA. */
+  .navbar .navbar-collapse .navbar-nav {
+    align-items: center;
+    text-align: center;
+  }
+
+  .navbar .navbar-collapse .nav-item {
+    width: 100%;
+  }
+
   .navbar .navbar-collapse {
     position: absolute;
     top: 100%;
@@ -912,6 +922,11 @@ body {
     width: fit-content;
     margin-left: 0;
     margin-top: 0.5rem;
+  }
+
+  /* Free space in the navbar while the dropdown is open. */
+  .navbar:has(.navbar-collapse.show) .navbar-brand img {
+    display: none;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the hamburger (mobile) dropdown presents all links centered for a cleaner mobile UX and keep the booking CTA visually aligned.
- Free up visual space in the navbar while the dropdown is open by hiding the site logo.

### Description
- Added CSS in `assets/theme.scss` under `@media (max-width: 991.98px)` to center `.navbar .navbar-collapse .navbar-nav` and set `.navbar .navbar-collapse .nav-item` to `width: 100%` so each menu item is centered and fills the dropdown width.
- Kept the booking CTA pill behavior (`width: fit-content`) so the CTA hugs its text while remaining centered in the dropdown.
- Hid the navbar logo while the mobile menu is open by adding `.navbar:has(.navbar-collapse.show) .navbar-brand img { display: none; }`.

### Testing
- Ran `git diff --check` which succeeded with no issues.
- Attempted `quarto --version` to render and validate visuals but Quarto is not installed in the environment, so render-based validation could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58f5add2dc8320811df3beb5dede17)