### PR TITLE
Keep site logo hidden on mobile

### DIFF
--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -924,8 +924,8 @@ body {
     margin-top: 0.5rem;
   }
 
-  /* Free space in the navbar while the dropdown is open. */
-  .navbar:has(.navbar-collapse.show) .navbar-brand img {
+  /* Keep the compact mobile navbar clear, whether or not its menu is open. */
+  .navbar .navbar-brand img {
     display: none;
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure the site logo/icon is not shown on mobile screens at the mobile breakpoint at all times instead of only hiding it when the hamburger menu is expanded.

### Description
- Change the mobile navbar CSS in `assets/theme.scss` to hide `.navbar .navbar-brand img` for the mobile breakpoint by replacing the `:has(.navbar-collapse.show)` selector with a selector that always applies inside the mobile media query.

### Testing
- Ran `git diff --check` (success) and attempted `npx --yes sass --no-source-map assets/theme.scss:/tmp/theme.css` which failed due to an HTTP 403 when fetching the Sass package in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58fa8831808320b86f8619d94ac73f)