### PR TITLE
Style dark-mode Download Resume button

### DIFF
--- a/assets/theme-dark.scss
+++ b/assets/theme-dark.scss
@@ -48,6 +48,19 @@ $input-bg: #13131a;
   filter: invert(1) hue-rotate(180deg);
 }
 
+/* Keep the resume download CTA distinct against the blue CTA panel. */
+.nw-btn-resume {
+  background: var(--nw-primary);
+  border: 1px solid #ffffff;
+  color: #ffffff !important;
+}
+
+.nw-btn-resume:hover {
+  background: #ffffff;
+  border-color: #ffffff;
+  color: var(--nw-primary) !important;
+}
+
 /* Leaflet chrome ships light-only; restyle controls and popups for dark */
 #map .leaflet-container {
   background: #0a0a0f;

--- a/index.qmd
+++ b/index.qmd
@@ -371,7 +371,7 @@ include-after-body:
     <div class="nw-cta-card">
       <h2>Open to Opportunities</h2>
       <p>I'm currently looking for <strong>data scientist</strong> or <strong>GIS analyst</strong> roles.<br>Let's connect and discuss how I can help your team.</p>
-      <div class="nw-btns"><a class="nw-btn nw-btn-primary" href="uploads/resume.pdf" target="_blank" rel="noopener">Download Resume</a></div>
+      <div class="nw-btns"><a class="nw-btn nw-btn-primary nw-btn-resume" href="uploads/resume.pdf" target="_blank" rel="noopener">Download Resume</a></div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
### Motivation
- Ensure the Download Resume CTA is visually distinct in dark mode by making it a blue button with white outline and white text that inverts on hover.

### Description
- Add a dedicated `nw-btn-resume` class to the Download Resume link in `index.qmd` and add dark-mode rules in `assets/theme-dark.scss` to use `var(--nw-primary)` background, a white border and text, and a hover state that becomes white with blue text.

### Testing
- Ran `git diff --check` which reported no issues and committed the changes, and attempted `quarto render` but it could not run because `quarto` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58fd6aff00832096d38438da9e15dd)