### PR TITLE
Center timeline dots vertically on card

### DIFF
--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -587,7 +587,8 @@ body {
   content: "";
   position: absolute;
   left: -2.23rem;
-  top: 1.75rem;
+  top: 50%;
+  transform: translateY(-50%);
   width: 0.9rem;
   height: 0.9rem;
   border-radius: 50%;


### PR DESCRIPTION
## Summary
- Timeline dots (`.nw-tl-item::before`) in the education/experience sections were pinned to `top: 1.75rem`, aligning them to the job-title line rather than the card as a whole.
- Changed to `top: 50%; transform: translateY(-50%)` so each dot is vertically centered on its card regardless of content height.

## Test plan
- [ ] Visually confirm timeline dots are centered on cards of varying heights (light and dark mode)

---
_Generated by [Claude Code](https://claude.ai/code/session_018uW6fqjCmoeCVfbcB6Nxm1)_