### PR TITLE
Narrow tech stack cards with top-aligned titles; simplify footer copyright

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -100,8 +100,7 @@ website:
       </div>
       </div>
       <div class="nw-footer-bottom">
-      <div>© 2026 Noah Weidig.</div>
-      <div>All Rights Reserved.</div>
+      <div>© 2026 Noah Weidig · Built with <a href="https://quarto.org">Quarto</a>.</div>
       </div>
       </div>
 

--- a/assets/site.css
+++ b/assets/site.css
@@ -81,7 +81,7 @@ body {
 /* ============ tech stack: single column, larger items ============ */
 .nw-stack {
   grid-template-columns: 1fr;
-  max-width: 60rem;
+  max-width: 36rem;
   margin: 0 auto;
   gap: 1.25rem;
 }
@@ -107,19 +107,6 @@ body {
   height: 3.25rem;
 }
 
-@media (min-width: 768px) {
-  .nw-stack-cat {
-    display: grid;
-    grid-template-columns: 10rem 1fr;
-    align-items: center;
-    justify-items: center;
-    padding: 1.75rem 2rem;
-  }
-
-  .nw-stack-cat h3 {
-    margin: 0;
-  }
-}
 
 /* ============ map: match the contact / CTA container width ============ */
 #map .nw-map {


### PR DESCRIPTION
## Changes

- **Tech stack cards** (`assets/site.css`): reduced `.nw-stack` max-width from 60rem to 36rem so cards no longer have excess horizontal space, and removed the ≥768px override that placed the category title in a left column — the title now sits at the top of each card at all viewport widths. The stack remains a single column.
- **Footer** (`_quarto.yml`): copyright line is now `© 2026 Noah Weidig · Built with <a href="https://quarto.org">Quarto</a>.`, replacing the previous two-line "All Rights Reserved" text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X75eGx8X2R6aCC94y4ZPvh

---
_Generated by [Claude Code](https://claude.ai/code/session_01X75eGx8X2R6aCC94y4ZPvh)_