### PR TITLE
Fix hidden project icons, contact form focus border, and project page image frame

### DIFF
--- a/_ejs/project-card.ejs
+++ b/_ejs/project-card.ejs
@@ -19,6 +19,7 @@ const nwProjIcons = {
   'wuirisk':        { g: 'g-amber',   svg: '<path d="M5 12l-2 0l9 -9l9 9l-2 0"/><path d="M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7"/><path d="M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6"/>' }
 };
 %>
+```{=html}
 <% for (const item of items) { %>
 <%
 const nwSegs = String(item.path).split('/').filter(Boolean);
@@ -38,3 +39,4 @@ const nwIcon = nwProjIcons[nwSlug] || { g: 'g-sky', svg: '<path d="M12 3l8 4.5v9
 </div>
 </div>
 <% } %>
+```

--- a/assets/nw-nav.js
+++ b/assets/nw-nav.js
@@ -93,7 +93,7 @@ document.addEventListener(
 
 // Project/award detail pages: surface the page's featured image below the title.
 (function () {
-  if (!/\/(projects|awards)\/[^/]+\/(index\.html)?$/.test(location.pathname)) return;
+  if (!/\/awards\/[^/]+\/(index\.html)?$/.test(location.pathname)) return;
   var meta = document.querySelector('meta[property="og:image"]');
   var header = document.getElementById("title-block-header");
   if (!meta || !header || document.querySelector(".nw-detail-hero")) return;

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -811,10 +811,6 @@ body {
   padding: 1.75rem;
 }
 
-.nw-form:focus-within {
-  border-color: var(--nw-primary);
-}
-
 .nw-form input,
 .nw-form textarea {
   width: 100%;


### PR DESCRIPTION
## Summary

- **Project icons not showing (#23 follow-up):** Pandoc was processing the listing template's HTML as markdown, escaping the SVG `<path>` tags into literal text (`&lt;path …&gt;`) and lowercasing `viewBox`, so only the gradient tiles rendered. The card markup in `_ejs/project-card.ejs` is now emitted inside a ```` ```{=html} ```` raw block so it passes through Pandoc verbatim. This fixes the icons on both the homepage and the projects listing.
- **Contact form:** removed the `.nw-form:focus-within` rule in `assets/theme.scss` that drew a blue border around the whole card while typing in the form.
- **Individual project pages:** `assets/nw-nav.js` no longer injects the framed `og:image` hero on `/projects/*` pages (projects no longer have card images, so it fell back to the site's default image). Awards pages keep the injected hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwX825YLfZEpQgccyPtpeW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwX825YLfZEpQgccyPtpeW)_