### PR TITLE
Remove underline from experience/education org links

### DIFF
--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -629,6 +629,11 @@ body {
 .nw-tl-item .nw-tl-org {
   font-weight: 600;
   color: var(--nw-primary);
+  text-decoration: none;
+}
+
+.nw-tl-item .nw-tl-org:hover {
+  text-decoration: underline;
 }
 
 .nw-tl-item .nw-tl-meta {


### PR DESCRIPTION
## Summary
- `.nw-tl-org` links (institutions/employers in Experience and Education timelines) no longer show a default underline
- Underline now appears only on hover; color and other styling unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwTX8Rt3q1mL2wwiEX4Fgj)_