### PR TITLE
Style blog post listings as cards with date under title

### DIFF
--- a/_ejs/post-row.ejs
+++ b/_ejs/post-row.ejs
@@ -1,9 +1,7 @@
 <% for (const item of items) { %>
 <div class="nw-post">
-<div class="nw-post-date"><%= item.date ? new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' }) : '' %></div>
-<div class="nw-post-body">
 <h3><a href="<%- item.path %>"><%= item.title %></a></h3>
+<div class="nw-post-date"><%= item.date ? new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' }) : '' %></div>
 <p><%= item.description || '' %></p>
-</div>
 </div>
 <% } %>

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -734,36 +734,47 @@ body {
 }
 
 /* ============ posts (blog listing) ============ */
-.nw-posts .nw-post {
-  display: flex;
+.nw-posts {
+  display: grid;
   gap: 1.5rem;
-  align-items: baseline;
-  padding: 1rem 0;
-  border-bottom: 1px solid var(--nw-border);
 }
 
-.nw-post-date {
-  flex: 0 0 7.5rem;
-  color: var(--nw-muted);
-  font-size: 0.88rem;
+.nw-posts .nw-post {
+  background: var(--nw-card);
+  border: 1px solid var(--nw-border);
+  border-radius: 1rem;
+  padding: 1.5rem 1.75rem;
+  transition: transform 0.2s, border-color 0.2s, box-shadow 0.2s;
 }
 
-.nw-post-body h3 {
+.nw-posts .nw-post:hover {
+  transform: translateY(-4px);
+  border-color: var(--nw-primary);
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.18);
+}
+
+.nw-post h3 {
   font-size: 1.1rem;
   font-weight: 700;
-  margin: 0 0 0.2rem;
+  margin: 0;
 }
 
-.nw-post-body h3 a {
+.nw-post h3 a {
   color: var(--nw-fg);
   text-decoration: none;
 }
 
-.nw-post-body h3 a:hover {
+.nw-post h3 a:hover {
   color: var(--nw-primary);
 }
 
-.nw-post-body p {
+.nw-post-date {
+  color: var(--nw-muted);
+  font-size: 0.85rem;
+  margin: 0.3rem 0 0.6rem;
+}
+
+.nw-post p {
   margin: 0;
   color: var(--nw-muted);
   font-size: 0.92rem;
@@ -927,7 +938,6 @@ body {
 }
 
 @media (max-width: 640px) {
-  .nw-post-date { flex-basis: 5.5rem; }
   .nw-section { padding: 3rem 0; }
 }
 


### PR DESCRIPTION
Blog post items in the homepage "Featured Posts" section and on the blog listing page now render as cards matching the rest of the site's card style (card background, 1px border, 1rem radius, hover lift/shadow), instead of plain rows separated by a bottom border.

- `_ejs/post-row.ejs`: the date moves from a left-hand column to a line directly beneath the post title; the `.nw-post-body` wrapper is gone.
- `assets/theme.scss`: `.nw-posts` becomes a grid of `.nw-post` cards styled like `.nw-card`/`.nw-proj-card`; the old flex row + date-column styles (including the 640px `flex-basis` override) are removed.

Both surfaces share the same EJS template and CSS, so one change covers both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XVJRtNyHpqm4QjsrzyHs7

---
_Generated by [Claude Code](https://claude.ai/code/session_014XVJRtNyHpqm4QjsrzyHs7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned the posts listing with a responsive card and grid layout.
  * Added bordered cards, padding, background styling, and hover elevation.
  * Updated post title, date, and spacing styles for improved readability.
  * Simplified the post markup while preserving existing date formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->