### PR TITLE
Home page card widths, nav CTA theming, clickable blog cards

### DIFF
--- a/assets/theme-dark.scss
+++ b/assets/theme-dark.scss
@@ -29,6 +29,7 @@ $input-bg: #13131a;
   --nw-glass: rgba(10, 10, 15, 0.85);
   --nw-glass-strong: rgba(10, 10, 15, 0.96);
   --nw-stat-number: #ffffff;
+  --nw-navcta: #ffffff;
 }
 
 /* solid mark renders black by default; flip to white on dark */

--- a/assets/theme-light.scss
+++ b/assets/theme-light.scss
@@ -28,6 +28,7 @@ $card-bg: #ffffff;
   --nw-glass: rgba(255, 255, 255, 0.85);
   --nw-glass-strong: rgba(255, 255, 255, 0.96);
   --nw-stat-number: #000000;
+  --nw-navcta: #000000;
 }
 
 /* solid mark stays black on light */

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -42,8 +42,8 @@ body {
 /* "Book Now" CTA styled as a button */
 .navbar .navbar-nav .nav-item a[href*="cal.com"] {
   background: transparent;
-  color: var(--nw-primary) !important;
-  border: 1px solid var(--nw-primary);
+  color: var(--nw-navcta) !important;
+  border: 1px solid var(--nw-navcta);
   border-radius: 999px;
   padding: 0.4rem 1.1rem !important;
   font-weight: 600;

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -451,6 +451,15 @@ body {
 }
 
 /* ============ citations (publications listing) ============ */
+/* home page: match featured pubs/posts width to education & experience timelines */
+#publications .nw-cites,
+#blog .nw-posts {
+  max-width: 46rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+
 .nw-cites .nw-cite {
   position: relative;
   background: var(--nw-card);

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -749,6 +749,7 @@ body {
 }
 
 .nw-posts .nw-post {
+  position: relative;
   background: var(--nw-card);
   border: 1px solid var(--nw-border);
   border-radius: 1rem;
@@ -775,6 +776,13 @@ body {
 
 .nw-post h3 a:hover {
   color: var(--nw-primary);
+}
+
+/* stretched link: the whole card navigates to the post */
+.nw-post h3 a::after {
+  content: "";
+  position: absolute;
+  inset: 0;
 }
 
 .nw-post-date {


### PR DESCRIPTION
Three small UI changes:

1. **Featured card widths** — caps the home page Featured Publications (`#publications .nw-cites`) and Featured Posts (`#blog .nw-posts`) lists at `max-width: 46rem` with auto margins, matching the Education and Experience timelines. Scoped by home-page section IDs so the full blog/publications listing pages are unchanged.
2. **Nav "Book Now" button** — new `--nw-navcta` theme variable: white border/text on dark mode, black on light mode; hover fills blue with white text in both modes.
3. **Clickable blog cards** — blog post cards (home page and blog listing, both use `post-row.ejs`) now navigate on a click anywhere in the card via the same stretched-link pattern used by publication cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZ2EFHwjubjtajomGayLgH