### PR TITLE
Book Now CTA: animate outline to primary blue on hover

### DIFF
--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -48,11 +48,12 @@ body {
   padding: 0.4rem 1.1rem !important;
   font-weight: 600;
   margin-left: 0.5rem;
-  transition: background-color 0.15s, color 0.15s, transform 0.15s;
+  transition: background-color 0.15s, border-color 0.15s, color 0.15s, transform 0.15s;
 }
 
 .navbar .navbar-nav .nav-item a[href*="cal.com"]:hover {
   background: var(--nw-primary);
+  border-color: var(--nw-primary);
   color: #fff !important;
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the navbar "Book Now" CTA uses the shared primary color for its outline on hover so the outline is visible and consistent in both light and dark modes and the change animates smoothly.

### Description
- Update `assets/theme.scss` to add `border-color` to the CTA `transition` and set `border-color: var(--nw-primary)` in the `.navbar .navbar-nav .nav-item a[href*="cal.com"]:hover` rule.

### Testing
- Ran `git diff --check` (passed) and a Node stylesheet assertion that verified the hover rule sets `border-color: var(--nw-primary)` (passed), and attempted `quarto render` which could not be run because Quarto is not installed in the environment (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a592d8c136483208d6f00ecbbfa38bd)