### PR TITLE
Add blue navbar hover underline

### DIFF
--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -39,6 +39,34 @@ body {
   font-weight: 700;
 }
 
+/* Navigation hover state and blue animated underline on desktop. */
+.navbar-expand-lg .navbar-nav .nav-link:hover {
+  color: $primary;
+}
+
+@media screen and (min-width: 992px) {
+  .navbar .navbar-nav .nav-item {
+    position: relative;
+  }
+
+  .navbar .navbar-nav .nav-item::after {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 0;
+    height: 4px;
+    margin: auto;
+    content: "";
+    background-color: $primary;
+    transition: width 0.3s;
+  }
+
+  .navbar .navbar-nav .nav-item:hover::after {
+    width: 90%;
+  }
+}
+
 /* "Book Now" CTA styled as a button */
 .navbar .navbar-nav .nav-item a[href*="cal.com"] {
   background: transparent;


### PR DESCRIPTION
### Motivation
- Make navbar link hover state visually consistent by using the primary blue and add a subtle animated underline on desktop for clearer affordance.

### Description
- Added a hover rule to apply `$primary` to expanded navbar links via `.navbar-expand-lg .navbar-nav .nav-link:hover` in `assets/theme.scss`.
- Added a desktop-only media query (`@media screen and (min-width: 992px)`) that uses a `::after` pseudo-element on `.navbar .navbar-nav .nav-item` to render a 4px blue underline that transitions to `width: 90%` on hover.
- Changes were saved and committed to `assets/theme.scss`.

### Testing
- Ran `git diff --check` which produced no issues and succeeded.
- Attempted `quarto check` but it could not be run because Quarto is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59456861048320bdc035e144b01e15)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced desktop navigation with a blue animated underline effect when hovering over links.
  * Improved hover-state color styling for navigation items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->