### PR TITLE
Restyle navbar controls with matching circular hover animations

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -4,9 +4,27 @@ html {
 }
 
 /* ============ color-scheme toggle: sun / moon icons ============ */
-.quarto-color-scheme-toggle {
-  margin-left: 8px !important;
-  margin-right: 8px !important;
+/* Circle around the toggle, sized to match the CTA button height, with the
+   same hover animation as the CTA and search: fills blue and the icon turns
+   white in both light and dark mode. */
+.quarto-navbar-tools .quarto-color-scheme-toggle {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  width: var(--nw-navctl);
+  height: var(--nw-navctl);
+  padding: 0 !important;
+  margin-left: 0.5rem !important;
+  margin-right: 0 !important;
+  border: 1px solid var(--nw-navcta);
+  border-radius: 50%;
+  box-sizing: border-box;
+  transition: background-color 0.15s, border-color 0.15s;
+}
+
+.quarto-navbar-tools .quarto-color-scheme-toggle:hover {
+  background: var(--nw-primary);
+  border-color: var(--nw-primary);
 }
 
 .quarto-color-scheme-toggle:not(.alternate) .bi::before {
@@ -15,6 +33,76 @@ html {
 
 body.quarto-dark .quarto-color-scheme-toggle > .bi::before {
   background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="%23d1d5db" class="bi bi-sun-fill" viewBox="0 0 16 16"><path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5zM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.414a.5.5 0 1 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707zM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707z"/></svg>') !important;
+}
+
+/* Hover: swap the icon to a white-filled variant (moon on light, sun on dark). */
+body:not(.quarto-dark) .quarto-navbar-tools .quarto-color-scheme-toggle:hover .bi::before {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="%23fff" viewBox="0 0 16 16"><path d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 0 1 .81.316.733.733 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 0 1 6 .278z"/></svg>') !important;
+}
+
+body.quarto-dark .quarto-navbar-tools .quarto-color-scheme-toggle:hover > .bi::before {
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="%23fff" class="bi bi-sun-fill" viewBox="0 0 16 16"><path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5zM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.414a.5.5 0 1 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707zM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707z"/></svg>') !important;
+}
+
+/* ============ navbar search: circle matching the toggle & CTA ============ */
+/* Overlay search renders a button.aa-DetachedSearchButton whose magnifier svg
+   paints with currentColor, so the hover just recolors it white. */
+#quarto-search.type-overlay .aa-DetachedSearchButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--nw-navctl);
+  height: var(--nw-navctl);
+  min-width: var(--nw-navctl);
+  padding: 0;
+  border: 1px solid var(--nw-navcta);
+  border-radius: 50%;
+  background: transparent;
+  color: var(--nw-navcta);
+  box-shadow: none;
+  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+}
+
+#quarto-search.type-overlay .aa-DetachedSearchButton:hover,
+#quarto-search.type-overlay .aa-DetachedSearchButton:focus {
+  background: var(--nw-primary);
+  border-color: var(--nw-primary);
+  color: #fff;
+  box-shadow: none;
+}
+
+#quarto-search .aa-DetachedSearchButtonIcon {
+  width: auto;
+  padding: 0;
+  color: inherit;
+}
+
+#quarto-search .aa-DetachedSearchButtonIcon .aa-SubmitIcon {
+  width: 1rem;
+  height: 1rem;
+}
+
+#quarto-search .aa-DetachedSearchButtonPlaceholder,
+#quarto-search .aa-DetachedSearchButtonQuery {
+  display: none;
+}
+
+/* Mobile: the brand's mx-auto centering was pulling the search + theme toggle
+   in toward the title. Anchor the brand hard-left so the tools stay pinned to
+   the right edge of the navbar. */
+@media (max-width: 991.98px) {
+  .navbar .navbar-container {
+    flex-wrap: nowrap;
+  }
+
+  .navbar .navbar-brand-container.mx-auto {
+    margin-left: 0 !important;
+    margin-right: auto !important;
+  }
+
+  .navbar .quarto-navbar-tools {
+    margin-left: 0.25rem;
+  }
 }
 
 /* full-bleed landing page: quarto's custom layout wrapper */

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -14,6 +14,9 @@ $navbar-padding-y: 0.65rem !default;
   --nw-primary: #0076DF;
   --nw-secondary: #0076DF;
   --nw-grad: linear-gradient(135deg, #0076DF, #0076DF);
+  /* shared height for the CTA button, so the theme-toggle and search circles
+     can size their diameter to match it exactly */
+  --nw-navctl: 2.4rem;
 }
 
 body {
@@ -39,41 +42,57 @@ body {
   font-weight: 700;
 }
 
-/* Navigation hover state and blue animated underline on desktop. */
+/* Navigation hover state on desktop. */
 .navbar-expand-lg .navbar-nav .nav-link:hover {
   color: $primary;
 }
 
+/* Desktop: on hover, draw a fully-rounded blue "pill" outline around the
+   nav-link text. Scoped to the left-hand text items (.me-auto) so the
+   "Book Now" CTA — which lives in .ms-auto and has its own pill styling —
+   never picks up this outline. */
 @media screen and (min-width: 992px) {
-  .navbar .navbar-nav .nav-item {
+  .navbar .navbar-nav.me-auto .nav-item {
     position: relative;
   }
 
-  .navbar .navbar-nav .nav-item::after {
-    position: absolute;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    width: 0;
-    height: 4px;
-    margin: auto;
-    content: "";
-    background-color: $primary;
-    transition: width 0.3s;
+  .navbar .navbar-nav.me-auto .nav-item .nav-link {
+    position: relative;
+    z-index: 1;
   }
 
-  .navbar .navbar-nav .nav-item:hover::after {
-    width: 90%;
+  .navbar .navbar-nav.me-auto .nav-item::after {
+    content: "";
+    position: absolute;
+    left: -0.1rem;
+    right: -0.1rem;
+    top: 50%;
+    height: 2rem;
+    border: 1.5px solid $primary;
+    border-radius: 999px;
+    opacity: 0;
+    transform: translateY(-50%) scale(0.92);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    pointer-events: none;
+  }
+
+  .navbar .navbar-nav.me-auto .nav-item:hover::after {
+    opacity: 1;
+    transform: translateY(-50%) scale(1);
   }
 }
 
-/* "Book Now" CTA styled as a button */
+/* "Book Now" CTA styled as a button. Height is pinned to --nw-navctl so the
+   theme-toggle and search circles can match its diameter. */
 .navbar .navbar-nav .nav-item a[href*="cal.com"] {
+  display: inline-flex;
+  align-items: center;
+  height: var(--nw-navctl);
   background: transparent;
   color: var(--nw-navcta) !important;
   border: 1px solid var(--nw-navcta);
   border-radius: 999px;
-  padding: 0.4rem 1.1rem !important;
+  padding: 0 1.1rem !important;
   font-weight: 600;
   margin-left: 0.5rem;
   transition: background-color 0.15s, border-color 0.15s, color 0.15s, transform 0.15s;
@@ -1017,7 +1036,7 @@ body {
 
   /* Book Now pill: hug the text instead of stretching across the dropdown */
   .navbar .navbar-nav .nav-item a[href*="cal.com"] {
-    display: inline-block;
+    display: inline-flex;
     width: fit-content;
     margin-left: 0;
     margin-top: 0.5rem;


### PR DESCRIPTION
## Summary

Unifies the hover treatment across the navbar's interactive controls so the **Book Now** CTA, the theme toggle, and the search icon all share one circular/pill hover style, and reworks the text nav-item hover.

## Changes

- **CTA "Book Now"** — removed the underline-on-hover animation; it now uses only its pill fill. Its height is pinned to a new `--nw-navctl` variable so the two icon circles can match it exactly.
- **Theme toggle (sun/moon)** — wrapped in a circle whose diameter equals the CTA height. On hover it fills blue and the icon turns white in **both** light (moon) and dark (sun) mode. Added white-filled icon variants for the hover state.
- **Search icon** — the overlay search button (`.aa-DetachedSearchButton`) gets the same circle + hover treatment; its magnifier paints with `currentColor`, so it turns white on the blue fill.
- **Nav text items** (Projects, Publications, …) — replaced the animated underline with a fully-rounded blue **pill outline** that draws around the link text on hover. Scoped to the left `.me-auto` group so the CTA is unaffected.
- **Mobile** — anchored the site brand hard-left so the theme toggle and search stay pinned to the right of the navbar instead of drifting toward the centered title.

## Verification

Rendered the compiled navbar (real DOM + Bootstrap bundle) in headless Chromium and screenshotted every state — desktop and mobile, light and dark, plus hover on each control (nav pill, toggle, search, CTA). All confirmed: circles equal the CTA height, icons invert to white on the blue hover fill in both themes, and the mobile toggle stays right-aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hYxyewC6BrGda1d9wrUo1

---
_Generated by [Claude Code](https://claude.ai/code/session_017hYxyewC6BrGda1d9wrUo1)_