### PR TITLE
Enlarge nav logo and match navbar control borders to social-icon gray

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -16,7 +16,7 @@ html {
   padding: 0 !important;
   margin-left: 0.5rem !important;
   margin-right: 0 !important;
-  border: 1px solid var(--nw-navcta);
+  border: 1px solid var(--nw-border);
   border-radius: 50%;
   box-sizing: border-box;
   transition: background-color 0.15s, border-color 0.15s;
@@ -55,7 +55,7 @@ body.quarto-dark .quarto-navbar-tools .quarto-color-scheme-toggle:hover > .bi::b
   height: var(--nw-navctl);
   min-width: var(--nw-navctl);
   padding: 0;
-  border: 1px solid var(--nw-navcta);
+  border: 1px solid var(--nw-border);
   border-radius: 50%;
   background: transparent;
   color: var(--nw-navcta);

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -35,7 +35,7 @@ body {
 }
 
 .navbar .navbar-brand img {
-  height: 1.75rem;
+  height: 2.5rem;
 }
 
 .navbar .navbar-title {
@@ -90,7 +90,7 @@ body {
   height: var(--nw-navctl);
   background: transparent;
   color: var(--nw-navcta) !important;
-  border: 1px solid var(--nw-navcta);
+  border: 1px solid var(--nw-border);
   border-radius: 999px;
   padding: 0 1.1rem !important;
   font-weight: 600;


### PR DESCRIPTION
## Changes

- **Larger site icon in the nav bar** — brand logo height `1.75rem` → `2.5rem`.
- **Gray borders on navbar controls** — the CTA button border, and the circles around the theme toggle and search icon, now use `var(--nw-border)` (the same gray as the circle around the hero social icons) instead of `var(--nw-navcta)`. Applies in both light and dark mode via the existing per-theme `--nw-border` values.
- Search icon already turns white on hover (existing `color:#fff` hover rule; icon inherits) — verified in place.

## Files

- `assets/theme.scss` — brand img height, CTA border.
- `assets/site.css` — theme-toggle circle border, search button circle border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEHnrbd8U3FkYaAi2Qj2Db)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated navigation and search control borders for more consistent theme styling.
  * Increased the navbar brand image size.
  * Refined the default “Book Now” button border color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->