### PR TITLE
Fix search icon staying black on hover in light mode

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -71,6 +71,13 @@ body.quarto-dark .quarto-navbar-tools .quarto-color-scheme-toggle:hover > .bi::b
   box-shadow: none;
 }
 
+/* Quarto's theme CSS colors the magnifier svg directly (color: #1f2937 on
+   light), which outranks the inherited hover color above, so force it. */
+#quarto-search.type-overlay .aa-DetachedSearchButton:hover .aa-SubmitIcon,
+#quarto-search.type-overlay .aa-DetachedSearchButton:focus .aa-SubmitIcon {
+  color: #fff !important;
+}
+
 #quarto-search .aa-DetachedSearchButtonIcon {
   width: auto;
   padding: 0;


### PR DESCRIPTION
On light mode, the navbar search icon stayed black when hovering the search button, instead of turning white like the theme toggle and CTA do.

**Cause:** Quarto's generated bootstrap CSS sets the magnifier SVG's color directly — `.navbar #quarto-search.type-overlay .aa-Autocomplete svg.aa-SubmitIcon { color: #1f2937 }` — which has higher specificity than the site's hover rule, which only sets `color: #fff` on the button and relies on inheritance. The dark theme's equivalent rule is white, which is why dark mode was unaffected.

**Fix:** Add a hover/focus rule in `assets/site.css` that forces the `.aa-SubmitIcon` white directly, matching the file's existing use of `!important` for overriding Quarto theme rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LhmVJ7oqiE1PkL2kKmw55

---
_Generated by [Claude Code](https://claude.ai/code/session_014LhmVJ7oqiE1PkL2kKmw55)_