### PR TITLE
Fix mobile theme-toggle position; outlined nav icons

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -27,21 +27,36 @@ html {
   border-color: var(--nw-primary);
 }
 
+/* Hand-drawn outlined (stroked) sun/moon, matching the site's line-icon style
+   (1.75 stroke, round caps — same as the back-to-top arrow). The glyph is a
+   flex item so it centers exactly in the circle, ignoring text baselines. */
+.quarto-navbar-tools .quarto-color-scheme-toggle .bi {
+  display: inline-flex;
+  line-height: 1;
+}
+
+.quarto-navbar-tools .quarto-color-scheme-toggle .bi::before {
+  width: 1.1rem !important;
+  height: 1.1rem !important;
+  background-size: 1.1rem 1.1rem !important;
+  vertical-align: 0;
+}
+
 .quarto-color-scheme-toggle:not(.alternate) .bi::before {
-  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="%23000" viewBox="0 0 16 16"><path d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 0 1 .81.316.733.733 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 0 1 6 .278z"/></svg>') !important;
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%23000" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>') !important;
 }
 
 body.quarto-dark .quarto-color-scheme-toggle > .bi::before {
-  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="%23d1d5db" class="bi bi-sun-fill" viewBox="0 0 16 16"><path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5zM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.414a.5.5 0 1 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707zM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707z"/></svg>') !important;
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%23d1d5db" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/></svg>') !important;
 }
 
-/* Hover: swap the icon to a white-filled variant (moon on light, sun on dark). */
+/* Hover: swap the icon to a white variant (moon on light, sun on dark). */
 body:not(.quarto-dark) .quarto-navbar-tools .quarto-color-scheme-toggle:hover .bi::before {
-  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="%23fff" viewBox="0 0 16 16"><path d="M6 .278a.768.768 0 0 1 .08.858 7.208 7.208 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 0 1 .81.316.733.733 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 0 1 6 .278z"/></svg>') !important;
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%23fff" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>') !important;
 }
 
 body.quarto-dark .quarto-navbar-tools .quarto-color-scheme-toggle:hover > .bi::before {
-  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="%23fff" class="bi bi-sun-fill" viewBox="0 0 16 16"><path d="M8 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5zM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.414a.5.5 0 1 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707zM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707z"/></svg>') !important;
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="%23fff" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/></svg>') !important;
 }
 
 /* ============ navbar search: circle matching the toggle & CTA ============ */
@@ -79,14 +94,20 @@ body.quarto-dark .quarto-navbar-tools .quarto-color-scheme-toggle:hover > .bi::b
 }
 
 #quarto-search .aa-DetachedSearchButtonIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: auto;
+  height: auto;
   padding: 0;
   color: inherit;
 }
 
+/* Quarto/algolia CSS sizes the magnifier svg itself, so force it down to
+   match the sun/moon glyph. */
 #quarto-search .aa-DetachedSearchButtonIcon .aa-SubmitIcon {
-  width: 1rem;
-  height: 1rem;
+  width: 1.1rem !important;
+  height: 1.1rem !important;
 }
 
 #quarto-search .aa-DetachedSearchButtonPlaceholder,
@@ -107,8 +128,17 @@ body.quarto-dark .quarto-navbar-tools .quarto-color-scheme-toggle:hover > .bi::b
     margin-right: auto !important;
   }
 
+  /* Quarto gives the tools order:3 / search order:4 with margin-left:auto,
+     so the leftover flex space split between the brand's auto right margin
+     and the search's auto left margin, stranding the toggle mid-bar. Kill
+     the search's auto margin and slot the toggle right after it. */
+  .navbar #quarto-search {
+    margin-left: 0 !important;
+  }
+
   .navbar .quarto-navbar-tools {
-    margin-left: 0.25rem;
+    order: 5;
+    margin-left: 0;
   }
 }
 


### PR DESCRIPTION
## Summary

- **Mobile toggle alignment:** on narrow viewports, Quarto gives `#quarto-search` `margin-left: auto` while our earlier fix gives the brand `margin-right: auto`. The two auto margins split the free flex space, leaving the theme toggle stranded ~halfway across the navbar instead of next to the search icon. The search's auto margin is now removed and the toggle is ordered directly after the search, so both sit as a tight pair flush against the right edge.
- **Outlined sun/moon icons:** replaced the filled Bootstrap glyphs with hand-drawn stroked (lined/outlined) sun and moon SVGs matching the site's other line icons (1.75 stroke, round caps), in all four states (light/dark × normal/hover).
- **Icon sizing/centering:** the search magnifier rendered at 26px vs the toggle's 17px; both glyphs are now the same 1.1rem and flex-centered exactly within their circles.

## Verification

Rendered the page headless at 390×844 and 1280×800 in both color schemes plus hover states; measured bounding boxes confirm the search + toggle are adjacent and flush right on mobile, and both glyphs are equal-sized and centered in their circles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ca73xAo54NjjJTY2CrN8y1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ca73xAo54NjjJTY2CrN8y1)_