### PR TITLE
Apply dark mode button styling to 404 page Go Home button

### DIFF
--- a/404.qmd
+++ b/404.qmd
@@ -10,7 +10,7 @@ toc: false
     <div class="nw-cta-card">
       <h2>404 — Page Not Found</h2>
       <p>The page you're looking for doesn't exist or has been moved.</p>
-      <div class="nw-btns"><a class="nw-btn nw-btn-primary" href="/">Go Home</a></div>
+      <div class="nw-btns"><a class="nw-btn nw-btn-primary nw-btn-resume" href="/">Go Home</a></div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
Apply the same dark mode aesthetics to the "Go Home" button on the 404 page as the "Download Resume" button uses.

## Changes
- Added `nw-btn-resume` class to the Go Home button on the 404 page
- This gives it a blue background with white text and border in dark mode, matching the Download Resume button styling

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6sfcbeLBsgRswsEguo3Va)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Page Not Found” screen with a clearer “Go Home” button presentation.
  * Improved button styling and behavior on the 404 page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->