### PR TITLE
Fix publication category tags linking to unfiltered home page

### DIFF
--- a/assets/nw-nav.js
+++ b/assets/nw-nav.js
@@ -9,27 +9,36 @@ document.addEventListener(
   true
 );
 
-// Detail pages: Quarto points title-block category tags at the home page,
-// where they do nothing. Send them to the section listing's filter instead.
+// Detail pages: Quarto points title-block category tags at whichever listing
+// the visitor came from (often the home page, where they do nothing). Send
+// them to the section listing's filter instead. quarto.js injects its links
+// asynchronously after fetching listings.json, so retarget on every DOM
+// change to the title block rather than just once at load.
 (function () {
   var m = location.pathname.match(/^\/(projects|publications|awards|blog)\//);
   if (!m) return;
-  document.querySelectorAll(".quarto-title .quarto-category").forEach(function (el) {
-    var cat = el.textContent.trim();
-    var href = "/" + m[1] + "/#category=" + encodeURIComponent(cat);
-    var parent = el.closest("a");
-    if (parent) {
-      parent.href = href;
-      // drop any listeners Quarto attached to the tag itself
-      el.replaceWith(el.cloneNode(true));
-    } else {
-      var a = document.createElement("a");
-      a.className = el.className;
-      a.textContent = cat;
-      a.href = href;
-      el.replaceWith(a);
-    }
-  });
+  var retarget = function () {
+    document.querySelectorAll(".quarto-title .quarto-category").forEach(function (el) {
+      var cat = el.textContent.trim();
+      var href = "/" + m[1] + "/#category=" + encodeURIComponent(cat);
+      var parent = el.closest("a");
+      if (parent) parent.href = href;
+      el.querySelectorAll("a").forEach(function (a) {
+        a.href = href;
+      });
+      if (!parent && !el.querySelector("a")) {
+        var a = document.createElement("a");
+        a.href = href;
+        while (el.firstChild) a.appendChild(el.firstChild);
+        el.appendChild(a);
+      }
+    });
+  };
+  retarget();
+  var header = document.getElementById("title-block-header");
+  if (header) {
+    new MutationObserver(retarget).observe(header, { childList: true, subtree: true });
+  }
 })();
 
 // Subtle back-to-top button, shown after scrolling down a bit.


### PR DESCRIPTION
## Problem

Clicking a publication type tag on an individual publication page navigates to `https://www.noahweidig.com/index.html#category=Journal%20Article` — the home page, which has no category filter — instead of the filtered publications listing.

## Root cause

Quarto's `quarto.js` linkifies title-block category tags **asynchronously**: on DOMContentLoaded it fetches `listings.json`, then wraps each tag in a link pointing back to a listing page containing the item — preferring the referrer (often the home page, whose `featured-pubs` listing "owns" the item too). The existing retarget block in `assets/nw-nav.js` ran once, synchronously at end-of-body — *before* Quarto injected its link — so Quarto's wrong href always landed last and won.

## Fix

Reworked the retarget block in `assets/nw-nav.js` to:
- set the correct `/<section>/#category=<cat>` href idempotently on any anchor wrapping or inside the tag (instead of a one-shot element replacement), and
- re-apply via a `MutationObserver` on `#title-block-header`, so when `quarto.js` later injects its own link it is immediately retargeted.

The `#category=` deep link is already handled on `/publications/` (and `/projects/`) by the existing filter-bar code in `assets/home.js`, so the tag now lands on the filtered publication-type list. The fallback anchor structure matches what `quarto.js` itself produces, so no visual change.

## Verification

Simulated the load race in jsdom (our script runs, then `quarto.js`-style late link injection with the wrong href): all resulting anchors point to `/publications/#category=Presentation`. `node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kg1jk4DFWjLJmFXJWqTBgD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kg1jk4DFWjLJmFXJWqTBgD)_