### PR TITLE
Center gridline background on viewport

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -153,6 +153,7 @@ body {
     linear-gradient(var(--nw-grid-line) 1px, transparent 1px),
     linear-gradient(90deg, var(--nw-grid-line) 1px, transparent 1px);
   background-size: 3.5rem 3.5rem;
+  background-position: center top;
 }
 
 /* sections sit transparent so the grid shows through; no gray alt bands */


### PR DESCRIPTION
## Summary
- Add `background-position: center top` to the body gridline background in `assets/site.css` so the grid stays horizontally centered on the viewport instead of anchoring to the top-left corner.

## Test plan
- [ ] Visually confirm the gridline is centered across page widths


---
_Generated by [Claude Code](https://claude.ai/code/session_01M2aGF6awMfooCeR8TThKcb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the grid-line background positioning so it consistently starts at the center top of the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->