### PR TITLE
Fix lightbox by embedding award images in page bodies

### DIFF
--- a/awards/best-student-presentation/index.qmd
+++ b/awards/best-student-presentation/index.qmd
@@ -8,3 +8,5 @@ featured: true
 ---
 
 I received the Best Student Presentation Award at the International Association of Landscape Ecology North America in 2025. There, I gave a talk about my master's research, which focused on wildfire risk in the wildland urban-interface (WUI) in the Eastern United States.
+
+![Best Student Presentation award](featured.webp){.lightbox fig-alt="Best Student Presentation award"}

--- a/awards/bioleaps-travel-grant/index.qmd
+++ b/awards/bioleaps-travel-grant/index.qmd
@@ -7,3 +7,5 @@ image-alt: BioLEAPS Travel Grant award certificate
 ---
 
 I received the BioLEAPS Travel Grant that covered all my travel expenses for attending the 2025 International Association of Landscape Ecology - North America annual conference in Raleigh, North Carolina.
+
+![BioLEAPS Travel Grant award certificate](featured.webp){.lightbox fig-alt="BioLEAPS Travel Grant award certificate"}

--- a/awards/graduate-research-assistantship/index.qmd
+++ b/awards/graduate-research-assistantship/index.qmd
@@ -8,3 +8,5 @@ image-alt: Graduate Research Assistantship award
 ---
 
 I was awarded a graduate research assistantship through the University of Florida's College of Agricultural & Life Sciences to support my master's research. This two-year position provided funding for my research on wildfire risk in the wildland-urban interface.
+
+![Graduate Research Assistantship award](featured.webp){.lightbox fig-alt="Graduate Research Assistantship award"}

--- a/awards/ifas-travel-grant/index.qmd
+++ b/awards/ifas-travel-grant/index.qmd
@@ -7,3 +7,5 @@ image-alt: IFAS Travel Grant award certificate
 ---
 
 I received the IFAS Travel Grant to support my travel to a professional conference. This award helped offset the costs of presenting my research and networking with colleagues in the agricultural and life sciences community.
+
+![IFAS Travel Grant award certificate](featured.webp){.lightbox fig-alt="IFAS Travel Grant award certificate"}

--- a/awards/lowe-scholarship/index.qmd
+++ b/awards/lowe-scholarship/index.qmd
@@ -7,3 +7,5 @@ image-alt: Doris and Earl Lowe and Verna Lowe Scholarship award
 ---
 
 I was awarded the Doris and Earl Lowe and Verna Lowe Scholarship in recognition of academic excellence and commitment to the field of agricultural and life sciences. This scholarship supported my graduate studies at the University of Florida.
+
+![Doris and Earl Lowe and Verna Lowe Scholarship award](featured.webp){.lightbox fig-alt="Doris and Earl Lowe and Verna Lowe Scholarship award"}

--- a/awards/milburn-research-fellowship/index.qmd
+++ b/awards/milburn-research-fellowship/index.qmd
@@ -7,3 +7,5 @@ image-alt: Dr. Carol Swarts Milburn Research Fellowship award
 ---
 
 I was awarded the Dr. Carol Swarts Milburn Research Fellowship from Northern Kentucky University to support my undergraduate research. This fellowship enabled me to pursue an independent research project in the biological sciences.
+
+![Dr. Carol Swarts Milburn Research Fellowship award](featured.webp){.lightbox fig-alt="Dr. Carol Swarts Milburn Research Fellowship award"}

--- a/awards/outstanding-graduate-biology/index.qmd
+++ b/awards/outstanding-graduate-biology/index.qmd
@@ -8,3 +8,5 @@ featured: true
 ---
 
 I was recognized as the Outstanding Graduate in Biology from Northern Kentucky University's Department of Biological Sciences upon completing my undergraduate degree. This honor reflected my academic achievements and contributions to the study of biology.
+
+![Outstanding Graduate in Biology award](featured.webp){.lightbox fig-alt="Outstanding Graduate in Biology award"}

--- a/awards/outstanding-teaching-assistant/index.qmd
+++ b/awards/outstanding-teaching-assistant/index.qmd
@@ -8,3 +8,5 @@ image-alt: Outstanding Teaching Assistant of the Year award
 ---
 
 I was selected as the Outstanding Teaching Assistant of the Year from the University of Florida's School of Forest, Fisheries, & Geomatic Sciences for the 2024 academic year. This award recognized my dedication to supporting student learning and fostering an inclusive classroom environment.
+
+![Outstanding Teaching Assistant of the Year award](featured.webp){.lightbox fig-alt="Outstanding Teaching Assistant of the Year award"}

--- a/awards/outstanding-thesis-forest-resources/index.qmd
+++ b/awards/outstanding-thesis-forest-resources/index.qmd
@@ -9,3 +9,5 @@ featured: true
 ---
 
 My master's thesis on wildfire risk in the wildland-urban interface was recognized as the Outstanding Thesis in Forest Resources & Conservation by the University of Florida's School of Forest, Fisheries, & Geomatic Sciences. This research focused on assessing and mitigating wildfire hazards in the Eastern United States.
+
+![Outstanding Thesis in Forest Resources and Conservation award](featured.webp){.lightbox fig-alt="Outstanding Thesis in Forest Resources and Conservation award"}

--- a/awards/outstanding-thesis-natural-resources/index.qmd
+++ b/awards/outstanding-thesis-natural-resources/index.qmd
@@ -9,3 +9,5 @@ featured: true
 ---
 
 My master's thesis on wildfire risk in the wildland-urban interface was also recognized as the Outstanding Thesis in Natural Resources by the University of Florida's College of Agricultural & Life Sciences. This award acknowledged the research's contribution to understanding and addressing natural resource challenges.
+
+![Outstanding Thesis in Natural Resources award](featured.webp){.lightbox fig-alt="Outstanding Thesis in Natural Resources award"}

--- a/awards/poster-competition-1st-place/index.qmd
+++ b/awards/poster-competition-1st-place/index.qmd
@@ -7,3 +7,5 @@ image-alt: 1st Place Undergraduate Student Poster Competition award
 ---
 
 I received first place in the Entomological Society of America's Undergraduate Student Poster Competition for my research presentation. This award recognized my contributions to entomological research and effective science communication.
+
+![1st Place Undergraduate Student Poster Competition award](featured.webp){.lightbox fig-alt="1st Place Undergraduate Student Poster Competition award"}

--- a/awards/presidents-list/index.qmd
+++ b/awards/presidents-list/index.qmd
@@ -7,3 +7,5 @@ image-alt: President's List award with 4.00 GPA designation
 ---
 
 For four consecutive years, I was recognized on the President's List at Northern Kentucky University for maintaining a 4.00 GPA.
+
+![President's List award with 4.00 GPA designation](featured.webp){.lightbox fig-alt="President's List award with 4.00 GPA designation"}

--- a/awards/student-travel-grant/index.qmd
+++ b/awards/student-travel-grant/index.qmd
@@ -7,3 +7,5 @@ image-alt: Student Travel Grant from International Association of Landscape Ecol
 ---
 
 I received the Student Travel Grant from the International Association of Landscape Ecology - North America to support my attendance at their 2025 annual conference. This award facilitated my participation in a premier professional meeting in landscape ecology.
+
+![Student Travel Grant from International Association of Landscape Ecology](featured.webp){.lightbox fig-alt="Student Travel Grant from International Association of Landscape Ecology"}


### PR DESCRIPTION
## Why lightbox wasn't working

`lightbox: auto` was enabled in `_quarto.yml` (c5a8eaf), but the site contains no Markdown images at all — every image is raw HTML (`<img>` in EJS card templates and `index.qmd`), and award certificates exist only as `image:` front matter consumed by listing cards. Quarto's lightbox filter only processes Pandoc-native Markdown images, so it had nothing to attach to and the GLightbox assets weren't even emitted.

Note: the `quarto-ext/lightbox` extension is **not** needed — lightbox has been built into Quarto since 1.4, and CI renders with 1.7.32. Installing the extension would not have fixed this either, for the same reason above.

## Change

Each of the 13 award pages now embeds its `featured.webp` in the page body as a Markdown figure with the `.lightbox` class (alt text taken from the existing `image-alt` front matter), so clicking the certificate opens it in a lightbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWcaga6ay5PEALHCrXDtF6

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWcaga6ay5PEALHCrXDtF6)_