### PR TITLE
Trim render-blocking requests and fix homepage SEO meta

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -123,6 +123,10 @@ format:
           <script src="/assets/nw-nav.js"></script>
     toc: false
     anchor-sections: false
+    # No page on the site uses LaTeX math, but Quarto still ships MathJax
+    # (285 KiB from jsDelivr) plus a render-blocking ES6 polyfill on listing
+    # pages. `plain` drops both; re-enable mathjax if a post ever needs math.
+    html-math-method: plain
     link-external-newwindow: true
     lang: en
     include-in-header:

--- a/assets/nw-nav.js
+++ b/assets/nw-nav.js
@@ -53,8 +53,16 @@ document.addEventListener(
     window.scrollTo({ top: 0, behavior: "smooth" });
   });
   document.body.appendChild(btn);
+  // Read scrollY inside rAF so the toggle doesn't force a synchronous reflow
+  // mid-scroll (headroom.js invalidates layout in the same scroll events).
+  var ticking = false;
   var onScroll = function () {
-    btn.classList.toggle("show", window.scrollY > 600);
+    if (ticking) return;
+    ticking = true;
+    requestAnimationFrame(function () {
+      btn.classList.toggle("show", window.scrollY > 600);
+      ticking = false;
+    });
   };
   window.addEventListener("scroll", onScroll, { passive: true });
   onScroll();

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -22,6 +22,11 @@
   }
 }
 
+// Cosmo's default $web-font-path @imports Source Sans Pro from Google Fonts at
+// the top of the compiled bootstrap.css — a render-blocking request for a font
+// nothing on the site uses (Inter replaces the whole stack). Disable it.
+$web-font-path: false;
+
 $font-family-sans-serif: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif !default;
 $primary: #0076DF !default;
 $link-color: #0076DF !default;

--- a/index.qmd
+++ b/index.qmd
@@ -1,5 +1,8 @@
 ---
 pagetitle: "Noah Weidig | GIS Analyst & Data Scientist"
+# Emits <meta name="description"> only; page-layout custom has no title block,
+# so nothing renders on the page itself.
+description: "Noah Weidig is an ecologist and GIS analyst specializing in geospatial data science, environmental modeling, and large-scale spatial analysis."
 page-layout: custom
 section-divs: false
 toc: false


### PR DESCRIPTION
Addresses the mobile Lighthouse findings (~3,050 ms est. render-blocking savings + SEO 92) without changing the site visually or functionally.

## Changes

- **`assets/theme.scss` — `$web-font-path: false;`**: Bootswatch cosmo's default injects a render-blocking `@import` of Source Sans Pro from `fonts.googleapis.com` (~850 ms) at the top of the compiled bootstrap.css. Nothing uses it — self-hosted Inter replaces the entire font stack (the compiled CSS contains zero `Source Sans` references).
- **`_quarto.yml` — `html-math-method: plain`**: no page on the site contains LaTeX math, but Quarto ships MathJax (285 KiB from jsDelivr) plus a render-blocking cdnjs ES6 polyfill (~790 ms) on listing pages anyway. `plain` drops both; a comment notes to re-enable `mathjax` if a future post needs math.
- **`index.qmd` — `description:` front matter**: the homepage lacked `<meta name="description">` (the SEO audit's only failure). With `page-layout: custom` there's no title block, so nothing renders on the page itself.
- **`assets/nw-nav.js`** — the back-to-top scroll handler now reads `scrollY` inside `requestAnimationFrame`, eliminating the forced-reflow warning (44 ms) at `nw-nav.js:57`.

## Not fixable from the repo

- **"Use efficient cache lifetimes" (536 KiB, 10m TTL)**: GitHub Pages serves a fixed `cache-control: max-age=600` on all assets and offers no way to change it. Fixing this would require a CDN with header control in front (e.g. Cloudflare with a cache rule on `/site_libs/*` and `/assets/*`).
- **`bootstrap-icons.woff` font-display (est. 20 ms)**: Quarto generates that `@font-face`; upstream Bootstrap Icons deliberately uses `font-display: block` because `swap` flashes tofu/fallback glyphs for icon codepoints. Left as-is to avoid a visual regression for a 20 ms estimate.

## Verification

- `node --check` on the edited JS and YAML parse both pass; the PR render check in `publish.yml` builds the full site.
- The compiled production CSS already proves `theme.scss` defaults win over cosmo's `!default` values (Inter replaced the cosmo font stack the same way), so the `$web-font-path` override is safe by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZvcrY5otz5BP6C8U579M1

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZvcrY5otz5BP6C8U579M1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved back-to-top button responsiveness by smoothing updates during page scrolling.

* **Style**
  * Standardized site typography around the Inter font stack and prevented unintended external font loading.

* **SEO & Accessibility**
  * Added a descriptive page summary to improve how the site is represented in search results and shared previews.

* **Configuration**
  * Updated math rendering behavior for more consistent HTML output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->