### PR TITLE
Move social share buttons above footer with "Share on:" label

### DIFF
--- a/_extensions/schochastics/social-share/social-share.css
+++ b/_extensions/schochastics/social-share/social-share.css
@@ -6,6 +6,13 @@
     flex-wrap: wrap;
 }
 
+.social-share .social-share-label {
+    flex-basis: 100%;
+    margin-bottom: 0.5em;
+    margin-left: 0.5em;
+    font-weight: 600;
+}
+
 .social-share a {
     border-radius: 25px;
     padding: 0.25rem 0.5rem;

--- a/assets/social-share.js
+++ b/assets/social-share.js
@@ -30,6 +30,35 @@
         });
       });
     });
+
+    relocate(containers);
+  }
+
+  // The Lua filter injects the share markup `after-body`, which lands *after*
+  // the page footer. Move each block to just before the footer (bottom of the
+  // page content) and prepend a "Share on:" label.
+  function relocate(containers) {
+    var footer = document.querySelector("#quarto-footer") ||
+      document.querySelector("footer.footer");
+    if (!footer) return;
+
+    containers.forEach(function (c) {
+      if (c.dataset.relocated) return;
+      c.dataset.relocated = "1";
+
+      if (!c.querySelector(".social-share-label")) {
+        var label = document.createElement("div");
+        label.className = "social-share-label";
+        label.textContent = "Share on:";
+        c.insertBefore(label, c.firstChild);
+      }
+
+      // Move the outer wrapper the filter created (falls back to the container).
+      var block = c.parentElement && c.parentElement !== document.body
+        ? c.parentElement
+        : c;
+      footer.parentNode.insertBefore(block, footer);
+    });
   }
 
   if (document.readyState === "loading") {


### PR DESCRIPTION
## Summary

The social share buttons were rendering out in the footer region because the Lua filter injects them `after-body` (after the page footer). This moves them to the bottom of the page content, just **above** the footer, and adds a "Share on:" label on the line above the icons.

## Changes

- `assets/social-share.js`: after rewriting each share link, relocate the share block to just before the footer (`#quarto-footer` / `footer.footer`) and prepend a `Share on:` label.
- `_extensions/schochastics/social-share/social-share.css`: style `.social-share-label` to occupy its own full-width line above the icon row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSyCt148D3SZNEMJgTb7vd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Social sharing sections now appear directly before the site footer.
  * Added a visible “Share on:” label to social sharing sections when needed.
  * Improved social sharing label layout and spacing.

* **Bug Fixes**
  * Prevented social sharing sections from being relocated more than once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->