### PR TITLE
Add browsable, print-to-PDF CV page

### DIFF
--- a/_ejs/cv-entry.ejs
+++ b/_ejs/cv-entry.ejs
@@ -1,0 +1,12 @@
+<% for (const item of items) { %>
+<div class="nw-cv-entry">
+<div class="nw-cv-entry-head">
+<div class="nw-cv-entry-title"><%= item.title %></div>
+<% const when = item.dates || (item.date ? new Date(item.date).getUTCFullYear() : ''); %><% if (when) { %><div class="nw-cv-entry-date"><%= when %></div><% } %>
+</div>
+<% if (item.org || item.location) { %>
+<div class="nw-cv-entry-meta"><% if (item.org) { %><% if (item['org-url']) { %><a href="<%- item['org-url'] %>" target="_blank" rel="noopener"><%= item.org %></a><% } else { %><span><%= item.org %></span><% } %><% } %><% if (item.org && item.location) { %> · <% } %><% if (item.location) { %><%= item.location %><% } %></div>
+<% } %>
+<% if (item.description) { %><p class="nw-cv-entry-desc"><%= item.description %></p><% } %>
+</div>
+<% } %>

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -53,6 +53,8 @@ website:
         href: index.qmd#awards
       - text: Blog
         href: index.qmd#blog
+      - text: CV
+        href: cv.qmd
       - text: Contact
         href: index.qmd#contact
     right:
@@ -98,6 +100,7 @@ website:
       <ul>
       <li><a href="/#publications"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3v4a1 1 0 0 0 1 1h4"/><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z"/><path d="M9 9h1"/><path d="M9 13h6"/><path d="M9 17h6"/></svg>Publications</a></li>
       <li><a href="/#blog"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 20h4l10.5 -10.5a2.83 2.83 0 0 0 -4 -4l-10.5 10.5v4"/><path d="M13.5 6.5l4 4"/></svg>Blog</a></li>
+      <li><a href="/cv"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3v4a1 1 0 0 0 1 1h4"/><path d="M5 21V5a2 2 0 0 1 2 -2h7l5 5v13a2 2 0 0 1 -2 2z"/><path d="M9 12h6"/><path d="M9 16h6"/><path d="M9 8h1"/></svg>CV</a></li>
       <li><a href="/#faq"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 17v.01"/><path d="M12 13.5a1.5 1.5 0 0 1 1 -1.5a2.6 2.6 0 1 0 -3 -4"/></svg>FAQ</a></li>
       </ul>
       </div>

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -1114,3 +1114,276 @@ body {
   height: 1.25rem;
   vertical-align: -0.25em;
 }
+
+/* ============ CV / curriculum vitae page ============ */
+.nw-cv {
+  max-width: 60rem;
+  margin: 0 auto;
+  padding: 2.5rem 1.25rem 4rem;
+}
+
+.nw-cv-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding-bottom: 1.5rem;
+  border-bottom: 2px solid var(--nw-border);
+}
+
+.nw-cv-name {
+  margin: 0;
+  font-size: 2.4rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.nw-cv-role {
+  margin: 0.25rem 0 0.5rem;
+  font-weight: 600;
+  color: var(--nw-primary);
+}
+
+.nw-cv-contact {
+  margin: 0;
+  color: var(--nw-muted);
+  font-size: 0.95rem;
+}
+
+.nw-cv-contact a {
+  color: var(--nw-fg);
+  text-decoration: none;
+}
+
+.nw-cv-contact a:hover {
+  color: var(--nw-primary);
+}
+
+.nw-cv-sep {
+  margin: 0 0.4rem;
+  opacity: 0.5;
+}
+
+.nw-cv-socials {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.nw-cv-socials a {
+  color: var(--nw-muted);
+}
+
+.nw-cv-socials a:hover {
+  color: var(--nw-primary);
+}
+
+.nw-cv-socials svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.nw-cv-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.nw-cv-actions .nw-btn {
+  padding: 0.55rem 1.2rem;
+  font-size: 0.9rem;
+  justify-content: center;
+}
+
+.nw-cv-summary {
+  margin: 1.5rem 0 0;
+  color: var(--nw-muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.nw-cv-section {
+  margin-top: 2.5rem;
+}
+
+.nw-cv-section > h2 {
+  font-size: 1.35rem;
+  font-weight: 700;
+  margin: 0 0 1.25rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--nw-border);
+}
+
+.nw-cv-section > h3 {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--nw-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 1.5rem 0 0.75rem;
+}
+
+.nw-cv-entry {
+  padding: 0.9rem 0;
+  border-bottom: 1px solid var(--nw-border);
+}
+
+.nw-cv-entry:last-child {
+  border-bottom: 0;
+}
+
+.nw-cv-entry-head {
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.nw-cv-entry-title {
+  font-weight: 700;
+  color: var(--nw-fg);
+}
+
+.nw-cv-entry-date {
+  flex: 0 0 auto;
+  color: var(--nw-muted);
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
+.nw-cv-entry-meta {
+  color: var(--nw-primary);
+  font-size: 0.92rem;
+  margin-top: 0.15rem;
+}
+
+.nw-cv-entry-meta a {
+  color: var(--nw-primary);
+  text-decoration: none;
+}
+
+.nw-cv-entry-meta a:hover {
+  text-decoration: underline;
+}
+
+.nw-cv-entry-desc {
+  margin: 0.4rem 0 0;
+  color: var(--nw-muted);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+/* publications on the CV render as a flat list (no cards) */
+.nw-cv .nw-cite {
+  padding: 0.7rem 0;
+  border-bottom: 1px solid var(--nw-border);
+}
+
+.nw-cv .nw-cite:last-child {
+  border-bottom: 0;
+}
+
+.nw-cv-skills {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.nw-cv-skill-row {
+  display: flex;
+  gap: 1rem;
+  align-items: baseline;
+}
+
+.nw-cv-skill-cat {
+  flex: 0 0 12rem;
+  font-weight: 700;
+  color: var(--nw-fg);
+}
+
+@media (max-width: 640px) {
+  .nw-cv-name {
+    font-size: 1.9rem;
+  }
+  .nw-cv-actions {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+  .nw-cv-skill-row {
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+  .nw-cv-skill-cat {
+    flex-basis: auto;
+  }
+}
+
+/* ============ print / save-as-PDF ============ */
+@media print {
+  /* strip site chrome so the CV prints as a clean document */
+  .navbar,
+  .nav-footer,
+  #quarto-back-to-top,
+  .nw-back-to-top,
+  #quarto-header,
+  .quarto-title-banner,
+  .aa-DetachedOverlay,
+  .nw-cv-actions,
+  .social-share,
+  #TOC {
+    display: none !important;
+  }
+
+  html,
+  body {
+    background: #fff !important;
+    color: #000 !important;
+  }
+
+  .nw-cv {
+    max-width: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .nw-cv-name,
+  .nw-cv-entry-title,
+  .nw-cv-section > h2 {
+    color: #000 !important;
+  }
+
+  .nw-cv-contact,
+  .nw-cv-summary,
+  .nw-cv-entry-desc,
+  .nw-cv-entry-date,
+  .nw-cv-section > h3 {
+    color: #333 !important;
+  }
+
+  a {
+    color: #000 !important;
+    text-decoration: none !important;
+  }
+
+  /* keep each role, degree, award, and citation intact across page breaks */
+  .nw-cv-entry,
+  .nw-cv .nw-cite,
+  .nw-cv-skill-row {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .nw-cv-section {
+    break-inside: auto;
+  }
+
+  .nw-cv-section > h2,
+  .nw-cv-section > h3 {
+    break-after: avoid;
+  }
+
+  @page {
+    margin: 1.5cm;
+  }
+}

--- a/cv.qmd
+++ b/cv.qmd
@@ -1,0 +1,168 @@
+---
+title: "Curriculum Vitae"
+description: "The full curriculum vitae of Noah Weidig — GIS Analyst & Data Scientist: education, experience, publications, presentations, and awards."
+page-layout: custom
+toc: false
+image: assets/media/authors/me.webp
+listing:
+  - id: cv-education
+    contents: "education/*/index.qmd"
+    sort: "date desc"
+    template: _ejs/cv-entry.ejs
+    fields: [title, org, org-url, dates, location, description, date, path]
+    page-size: 100
+  - id: cv-experience
+    contents: "experience/*/index.qmd"
+    sort: "date desc"
+    template: _ejs/cv-entry.ejs
+    fields: [title, org, org-url, dates, location, description, date, path]
+    page-size: 100
+  - id: cv-pubs-journal
+    contents: "publications/*/index.qmd"
+    sort: "date desc"
+    include:
+      categories: "Journal Article"
+    template: _ejs/citation.ejs
+    page-size: 100
+  - id: cv-pubs-thesis
+    contents: "publications/*/index.qmd"
+    sort: "date desc"
+    include:
+      categories: "Thesis"
+    template: _ejs/citation.ejs
+    page-size: 100
+  - id: cv-pubs-presentation
+    contents: "publications/*/index.qmd"
+    sort: "date desc"
+    include:
+      categories: "Presentation"
+    template: _ejs/citation.ejs
+    page-size: 100
+  - id: cv-pubs-webinar
+    contents: "publications/*/index.qmd"
+    sort: "date desc"
+    include:
+      categories: "Webinar"
+    template: _ejs/citation.ejs
+    page-size: 100
+  - id: cv-pubs-media
+    contents: "publications/*/index.qmd"
+    sort: "date desc"
+    include:
+      categories: "Media Coverage"
+    template: _ejs/citation.ejs
+    page-size: 100
+  - id: cv-pubs-service
+    contents: "publications/*/index.qmd"
+    sort: "date desc"
+    include:
+      categories: "Peer Review"
+    template: _ejs/citation.ejs
+    page-size: 100
+  - id: cv-awards
+    contents: "awards/*/index.qmd"
+    sort: "date desc"
+    template: _ejs/cv-entry.ejs
+    fields: [title, org, org-url, dates, location, description, date, path]
+    page-size: 100
+---
+
+::: {.nw-cv}
+
+```{=html}
+<header class="nw-cv-header">
+  <div class="nw-cv-id">
+    <h1 class="nw-cv-name">Noah Weidig</h1>
+    <p class="nw-cv-role">GIS Analyst &amp; Data Scientist</p>
+    <p class="nw-cv-contact">
+      <a href="mailto:noah@noahweidig.com">noah@noahweidig.com</a>
+      <span class="nw-cv-sep">·</span>
+      Gainesville, FL
+      <span class="nw-cv-sep">·</span>
+      <a href="https://noahweidig.com/">noahweidig.com</a>
+    </p>
+    <div class="nw-cv-socials">
+      <a href="https://www.linkedin.com/in/noahweidig/" aria-label="LinkedIn" target="_blank" rel="noopener"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><path d="M8 11v5"/><path d="M8 8v.01"/><path d="M12 16v-5"/><path d="M16 16v-3a2 2 0 0 0 -4 0"/></svg></a>
+      <a href="https://github.com/noahweidig/" aria-label="GitHub" target="_blank" rel="noopener"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-4.3 1.4 -4.3 -2.5 -6 -3m12 5v-3.5c0 -1 .1 -1.4 -.5 -2c2.8 -.3 5.5 -1.4 5.5 -6.1a4.6 4.6 0 0 0 -1.3 -3.2a4.2 4.2 0 0 0 -.1 -3.2s-1.1 -.3 -3.5 1.3a12.3 12.3 0 0 0 -6.2 0c-2.4 -1.6 -3.5 -1.3 -3.5 -1.3a4.2 4.2 0 0 0 -.1 3.2a4.6 4.6 0 0 0 -1.3 3.2c0 4.6 2.7 5.7 5.5 6.1c-.6 .6 -.6 1.2 -.5 2v3.5"/></svg></a>
+      <a href="https://scholar.google.com/citations?hl=en&user=Ml95eTwAAAAJ" aria-label="Google Scholar" target="_blank" rel="noopener"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 9l-10 -4l-10 4l10 4l10 -4v6"/><path d="M6 10.6v5.4a6 3 0 0 0 12 0v-5.4"/></svg></a>
+      <a href="https://orcid.org/0000-0003-1205-3209" aria-label="ORCID" target="_blank" rel="noopener"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M9 10v6"/><path d="M9 7v.01"/><path d="M12.5 16v-6h2a3 3 0 0 1 0 6z"/></svg></a>
+    </div>
+  </div>
+  <div class="nw-cv-actions">
+    <button type="button" class="nw-btn nw-btn-primary" onclick="window.print()">Print / Save as PDF</button>
+    <a class="nw-btn nw-btn-ghost" href="uploads/resume.pdf" target="_blank" rel="noopener">One-page Résumé</a>
+  </div>
+</header>
+
+<p class="nw-cv-summary">GIS &amp; Remote Sensing Research Associate leveraging remote sensing, GIS, and data science to translate complex geospatial data into clear insight about how our world changes. Focused on wildland-urban interface wildfire risk, land-use change, and spatial decision-making.</p>
+```
+
+
+
+::: {.nw-cv-section}
+## Education
+::: {#cv-education}
+:::
+:::
+
+::: {.nw-cv-section}
+## Experience
+::: {#cv-experience}
+:::
+:::
+
+::: {.nw-cv-section}
+## Publications
+### Journal Articles
+::: {#cv-pubs-journal}
+:::
+### Thesis
+::: {#cv-pubs-thesis}
+:::
+:::
+
+::: {.nw-cv-section}
+## Presentations
+::: {#cv-pubs-presentation}
+:::
+:::
+
+::: {.nw-cv-section}
+## Webinars
+::: {#cv-pubs-webinar}
+:::
+:::
+
+::: {.nw-cv-section}
+## Media Coverage
+::: {#cv-pubs-media}
+:::
+:::
+
+::: {.nw-cv-section}
+## Service
+### Peer Review
+::: {#cv-pubs-service}
+:::
+:::
+
+::: {.nw-cv-section}
+## Awards &amp; Honors
+::: {#cv-awards}
+:::
+:::
+
+::: {.nw-cv-section}
+## Skills
+```{=html}
+<div class="nw-cv-skills">
+  <div class="nw-cv-skill-row"><span class="nw-cv-skill-cat">Languages</span><span>R, Python, JavaScript, SQL</span></div>
+  <div class="nw-cv-skill-row"><span class="nw-cv-skill-cat">Markup</span><span>Markdown, LaTeX, HTML, CSS</span></div>
+  <div class="nw-cv-skill-row"><span class="nw-cv-skill-cat">Libraries</span><span>tidyverse, pandas, NumPy, Plotly</span></div>
+  <div class="nw-cv-skill-row"><span class="nw-cv-skill-cat">GIS &amp; Remote Sensing</span><span>ArcGIS Pro, Google Earth Engine, QGIS, GDAL, sf, terra, GeoPandas, OpenStreetMap</span></div>
+  <div class="nw-cv-skill-row"><span class="nw-cv-skill-cat">Workflows</span><span>Git, GitHub, GitHub Actions, Conda</span></div>
+</div>
+```
+:::
+
+:::


### PR DESCRIPTION
## Summary

Adds a dedicated **`/cv`** page — a full, browsable academic curriculum vitae that assembles itself from the *same* structured front-matter the rest of the site already uses (`education/`, `experience/`, `publications/`, `awards/`). Because it's built from Quarto listings, it regenerates on every build — including the twice-monthly Zotero publication refresh — so it never drifts out of sync, and it prints / saves to PDF cleanly from the browser.

This augments (does not replace) the existing one-page `uploads/resume.pdf`, which is still linked from the CV header.

## What changed

- **`cv.qmd`** (new): header with contact links + a `Print / Save as PDF` button, a short professional summary, and Quarto listings for Education, Experience, Publications (grouped by type — Journal Articles, Thesis, Presentations, Webinars, Media Coverage, Peer Review), Awards & Honors, and Skills. Uses `page-layout: custom` (matching `index.qmd`) so there's no duplicate title block; `title`/`description`/`image` drive SEO + the auto-generated OG card.
- **`_ejs/cv-entry.ejs`** (new): a print-clean entry template (no card chrome / hover-lift / stretched link) reusing the existing `title` / `org` / `org-url` / `dates` / `location` / `description` fields. Publications reuse the existing `_ejs/citation.ejs` unchanged.
- **`assets/theme.scss`**: `.nw-cv*` styling built on the site's existing `--nw-*` design tokens and `.nw-btn` conventions, plus an `@media print` block that strips the navbar/footer/theme-toggle/back-to-top, forces black-on-white, and uses `break-inside: avoid` so roles, degrees, awards, and citations don't split across pages.
- **`_quarto.yml`**: adds a **CV** link to the navbar and to the footer's Resources column.

No existing content files were edited — the CV reads their front-matter directly, so there is no content duplication.

## Verification

Quarto isn't installable in this environment (GitHub release downloads are blocked by egress policy), so the authoritative render happens in CI on this PR. Static checks completed locally:

- `cv.qmd` and `_quarto.yml` parse as valid YAML.
- All nine listing `id`s match their `::: {#id}` target divs.
- `assets/theme.scss` braces balance (220/220).
- Fenced-div / raw-HTML wrapper balances (switched the outer wrapper to an idiomatic `::: {.nw-cv}` fenced div).

Once CI renders, please confirm in the preview: all sections populate from the folder data, publications are grouped by type and ordered newest-first, light/dark theming holds, and browser Print preview produces a clean single-column PDF with site chrome hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013cmri6BAXcRV8fYPmo7Qio

---
_Generated by [Claude Code](https://claude.ai/code/session_013cmri6BAXcRV8fYPmo7Qio)_