### PR TITLE
Fix CV print/résumé actions, align CV title, balance footer columns

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -84,6 +84,7 @@ website:
       <li><a href="/#experience"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="7" width="18" height="13" rx="2"/><path d="M8 7V5a2 2 0 0 1 2 -2h4a2 2 0 0 1 2 2v2"/><path d="M12 12v.01"/><path d="M3 13a20 20 0 0 0 18 0"/></svg>Experience</a></li>
       <li><a href="/#education"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21h18"/><path d="M3 10h18"/><path d="M5 6l7 -3l7 3"/><path d="M4 10v11"/><path d="M20 10v11"/><path d="M8 14v3"/><path d="M12 14v3"/><path d="M16 14v3"/></svg>Education</a></li>
       <li><a href="/#skills"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4l4 4"/><path d="M17 8l4 4l-4 4"/><path d="M14 4l-4 16"/></svg>Skills</a></li>
+      <li><a href="/#affiliations"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="7" r="3"/><path d="M3 20v-1a5 5 0 0 1 10 0v1"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/><path d="M21 20v-1a5 5 0 0 0 -3 -4.5"/></svg>Affiliations</a></li>
       </ul>
       </div>
       <div class="nw-footer-col">
@@ -92,6 +93,7 @@ website:
       <li><a href="/#projects"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 13a8 8 0 0 1 7 7a6 6 0 0 0 3 -5a9 9 0 0 0 6 -8a3 3 0 0 0 -3 -3a9 9 0 0 0 -8 6a6 6 0 0 0 -5 3"/><path d="M7 14a6 6 0 0 0 -3 6a6 6 0 0 0 6 -3"/><circle cx="15" cy="9" r="1"/></svg>Projects</a></li>
       <li><a href="https://noahweidig.com/geo-portfolio"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7l6 -3l6 3l6 -3v13l-6 3l-6 -3l-6 3z"/><path d="M9 4v13"/><path d="M15 7v13"/></svg>Geo Portfolio</a></li>
       <li><a href="/#awards"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 21h8"/><path d="M12 17v4"/><path d="M7 4h10v6a5 5 0 0 1 -10 0z"/><path d="M7 6h-2a2 2 0 0 0 0 4h2"/><path d="M17 6h2a2 2 0 0 1 0 4h-2"/></svg>Awards</a></li>
+      <li><a href="/#interests"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18h6"/><path d="M10 22h4"/><path d="M12 2a7 7 0 0 1 4 12.7a2 2 0 0 0 -.8 1.6v.7h-6.4v-.7a2 2 0 0 0 -.8 -1.6a7 7 0 0 1 4 -12.7z"/></svg>Interests</a></li>
       </ul>
       </div>
       <div class="nw-footer-col">
@@ -109,6 +111,7 @@ website:
       <li><a href="mailto:noah@noahweidig.com"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 7l9 6l9 -6"/></svg>Email</a></li>
       <li><a href="/#contact"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 9h8"/><path d="M8 13h6"/><path d="M18 4a3 3 0 0 1 3 3v8a3 3 0 0 1 -3 3h-5l-5 3v-3h-2a3 3 0 0 1 -3 -3v-8a3 3 0 0 1 3 -3h12z"/></svg>Contact</a></li>
       <li><a href="https://cal.com/noah-weidig/meet" target="_blank" rel="noopener"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="16" rx="2"/><path d="M16 3v4"/><path d="M8 3v4"/><path d="M4 11h16"/><path d="M11 15h1"/><path d="M12 15v3"/></svg>Book a Call</a></li>
+      <li><a href="https://www.linkedin.com/in/noahweidig/" target="_blank" rel="noopener"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><path d="M8 11v5"/><path d="M8 8v.01"/><path d="M12 16v-5"/><path d="M16 16v-3a2 2 0 0 0 -4 0"/></svg>LinkedIn</a></li>
       </ul>
       </div>
       </div>

--- a/assets/nw-nav.js
+++ b/assets/nw-nav.js
@@ -41,6 +41,15 @@ document.addEventListener(
   }
 })();
 
+// CV page: trigger the browser print dialog from the "Print / Save as PDF"
+// button. Bound in JS rather than an inline onclick so it fires reliably.
+document.addEventListener("click", function (e) {
+  var btn = e.target.closest && e.target.closest(".nw-cv-print");
+  if (!btn) return;
+  e.preventDefault();
+  window.print();
+});
+
 // Subtle back-to-top button, shown after scrolling down a bit.
 (function () {
   var btn = document.createElement("button");

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -1122,6 +1122,19 @@ body {
   padding: 2.5rem 1.25rem 4rem;
 }
 
+/* The custom-layout title block ("Curriculum Vitae" + description) spans the
+   full content column, so it sits left of the narrower .nw-cv body. Constrain
+   it to the same max-width, centering, and horizontal padding so it lines up. */
+body:has(.nw-cv) #title-block-header {
+  max-width: 60rem;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+  box-sizing: border-box;
+  width: 100%;
+}
+
 .nw-cv-header {
   display: flex;
   flex-wrap: wrap;

--- a/cv.qmd
+++ b/cv.qmd
@@ -89,8 +89,8 @@ listing:
     </div>
   </div>
   <div class="nw-cv-actions">
-    <button type="button" class="nw-btn nw-btn-primary" onclick="window.print()">Print / Save as PDF</button>
-    <a class="nw-btn nw-btn-ghost" href="uploads/resume.pdf" target="_blank" rel="noopener">One-page Résumé</a>
+    <button type="button" class="nw-btn nw-btn-primary nw-cv-print">Print / Save as PDF</button>
+    <a class="nw-btn nw-btn-ghost" href="/uploads/resume.pdf" target="_blank" rel="noopener">One-page Résumé</a>
   </div>
 </header>
 


### PR DESCRIPTION
## Summary

Addresses three issues on the CV page and site footer.

### CV print & résumé buttons
- The "Print / Save as PDF" button now fires the print dialog via a delegated JS handler (`.nw-cv-print` in `assets/nw-nav.js`) instead of an inline `onclick`, so it triggers reliably regardless of inline-handler quirks.
- The "One-page Résumé" link is now an absolute path (`/uploads/resume.pdf`) instead of a relative one, removing any base-path ambiguity depending on how `/cv` is served.

### CV title alignment
- The custom-layout title block (`#title-block-header`) spanned the full content column, so "Curriculum Vitae" and its description sat ~95px left of the narrower `.nw-cv` body. It is now constrained to the same `max-width: 60rem`, centering, and `1.25rem` horizontal padding so the heading lines up with the rest of the page.

### Footer — even rows per column
- After CV was added, the Resources column had 4 rows while the others had 3. Added a fourth link (with matching icon) to each remaining list column so all four are even:
  - **About** → Affiliations (`/#affiliations`)
  - **Work** → Interests (`/#interests`)
  - **Connect** → LinkedIn

## Files changed
- `cv.qmd` — print button class + absolute résumé href
- `assets/nw-nav.js` — delegated print handler
- `assets/theme.scss` — title-block alignment
- `_quarto.yml` — footer column items

## Testing notes
Quarto is not available in this environment, so changes were verified by source review. Please confirm on a rendered build: the print button opens the print dialog, the résumé opens the PDF, the CV title aligns with the body, and the footer columns each show four rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ade4P5wLkES9w7in8D2d39

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ade4P5wLkES9w7in8D2d39)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added footer links for Affiliations, Interests, and LinkedIn.
  * Added a print/save-as-PDF action to the Curriculum Vitae page.
  * Added a direct download link for the one-page résumé.

* **Bug Fixes**
  * Improved Curriculum Vitae header alignment and spacing across layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->