### PR TITLE
Nav-to-title spacing, Facebook share, centered share row, CV print hardening

### DIFF
--- a/_extensions/schochastics/social-share/social-share.css
+++ b/_extensions/schochastics/social-share/social-share.css
@@ -2,14 +2,15 @@
 .social-share {
     display: flex;
     flex-direction: row;
-    justify-content: left;
+    justify-content: center;
     flex-wrap: wrap;
 }
 
 .social-share .social-share-label {
     flex-basis: 100%;
     margin-bottom: 0.5em;
-    margin-left: 0.5em;
+    margin-left: 0;
+    text-align: center;
     font-weight: 600;
 }
 
@@ -20,7 +21,8 @@
     border: 1px solid transparent;
     transition: background ease 0.3s, color ease 0.3s;
     margin-bottom: 1em;
-    margin-left: 0.5em;
+    margin-left: 0.25em;
+    margin-right: 0.25em;
     text-decoration: none;
 }
 

--- a/assets/nw-nav.js
+++ b/assets/nw-nav.js
@@ -42,13 +42,35 @@ document.addEventListener(
 })();
 
 // CV page: trigger the browser print dialog from the "Print / Save as PDF"
-// button. Bound in JS rather than an inline onclick so it fires reliably.
-document.addEventListener("click", function (e) {
-  var btn = e.target.closest && e.target.closest(".nw-cv-print");
-  if (!btn) return;
-  e.preventDefault();
-  window.print();
-});
+// button. Bound in JS (capture phase) rather than an inline onclick so it
+// fires reliably and beats any ancestor <a> that might otherwise navigate.
+document.addEventListener(
+  "click",
+  function (e) {
+    var btn = e.target.closest && e.target.closest(".nw-cv-print");
+    if (!btn) return;
+    e.preventDefault();
+    e.stopPropagation();
+    window.print();
+  },
+  true
+);
+
+// CV page: defensively unwrap any anchor that ends up wrapping the CV header
+// or body, so the top section (name, contact, Print/Résumé buttons) is never
+// turned into one giant link.
+(function () {
+  var cv = document.querySelector(".nw-cv");
+  if (!cv) return;
+  [cv, cv.querySelector(".nw-cv-header")].forEach(function (el) {
+    if (!el) return;
+    var a = el.closest("a");
+    if (a && a.parentNode) {
+      while (a.firstChild) a.parentNode.insertBefore(a.firstChild, a);
+      a.parentNode.removeChild(a);
+    }
+  });
+})();
 
 // Subtle back-to-top button, shown after scrolling down a bit.
 (function () {

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -1032,6 +1032,18 @@ body {
   letter-spacing: -0.02em;
 }
 
+/* Breathing room between the fixed navbar and each page's title. The home page
+   uses a custom layout with no title block, so it's unaffected. */
+#title-block-header {
+  margin-top: 1.75rem;
+}
+
+@media (max-width: 640px) {
+  #title-block-header {
+    margin-top: 2.5rem;
+  }
+}
+
 /* Experience/education detail pages: org · dates · location lead line. */
 .nw-detail-lead {
   color: var(--nw-muted);

--- a/awards/_metadata.yml
+++ b/awards/_metadata.yml
@@ -7,4 +7,5 @@ share:
   linkedin: true
   bsky: true
   reddit: true
+  facebook: true
   email: true

--- a/blog/_metadata.yml
+++ b/blog/_metadata.yml
@@ -15,4 +15,5 @@ share:
   linkedin: true
   bsky: true
   reddit: true
+  facebook: true
   email: true

--- a/education/_metadata.yml
+++ b/education/_metadata.yml
@@ -7,4 +7,5 @@ share:
   linkedin: true
   bsky: true
   reddit: true
+  facebook: true
   email: true

--- a/experience/_metadata.yml
+++ b/experience/_metadata.yml
@@ -7,4 +7,5 @@ share:
   linkedin: true
   bsky: true
   reddit: true
+  facebook: true
   email: true

--- a/projects/_metadata.yml
+++ b/projects/_metadata.yml
@@ -7,4 +7,5 @@ share:
   linkedin: true
   bsky: true
   reddit: true
+  facebook: true
   email: true

--- a/publications/_metadata.yml
+++ b/publications/_metadata.yml
@@ -7,4 +7,5 @@ share:
   linkedin: true
   bsky: true
   reddit: true
+  facebook: true
   email: true


### PR DESCRIPTION
## Summary

- **Nav → title spacing:** Added breathing room between the fixed navbar and each page's title block (`#title-block-header`), with a larger gap on mobile where it was tightest. The home page uses a custom layout with no title block, so it's untouched.
- **Facebook share:** Enabled the Facebook button on all content pages (blog, projects, publications, education, awards, experience). The `quarto-social-share` filter and the per-page URL rewriter (`assets/social-share.js`) already supported Facebook — this just turns it on.
- **Centered share row:** The "Share on:" label and social icons now center instead of left-aligning.
- **CV page:**
  - Print / Save as PDF is now bound in the **capture phase** with `stopPropagation()`, so the print dialog always wins over any ancestor link (fixes the button appearing dead when the deployed `nw-nav.js` was stale).
  - Added a defensive guard that **unwraps any anchor** ending up around the CV header, so the top section can never render as one giant link.
  - Print margins are already handled by the existing `@page { margin: 1.5cm }` print rule.

## Notes

Inspecting the currently served `/cv` markup, there is no anchor wrapping the header today — the "whole top section is a link to the referee report" you saw came from a mid-flight deploy serving a stale `nw-nav.js`. The capture-phase print binding + the header-unwrap guard make that state impossible going forward, and a fresh deploy refreshes the cached assets.

## Testing

- `node --check assets/nw-nav.js` passes.
- Header-anchor absence verified against the live page via raw-HTML anchor-depth tracing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018EkPrGCmRzf5jiUiJw4UKs)_