### PR TITLE
Fix CV click-blocking overlay and print margins; add View Full CV button

### DIFF
--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -555,8 +555,11 @@ body {
   text-decoration: none;
 }
 
-/* stretched link: the whole card navigates to the publication page */
-.nw-cite-title a::after {
+/* stretched link: the whole card navigates to the publication page.
+   Scoped to .nw-cites (the publications listing cards) — on the CV the
+   .nw-cite entries are flat, unpositioned rows, so an unscoped ::after
+   would resolve against the page and blanket it in an invisible link. */
+.nw-cites .nw-cite-title a::after {
   content: "";
   position: absolute;
   inset: 0;
@@ -1299,8 +1302,10 @@ body:has(.nw-cv) #title-block-header {
   line-height: 1.55;
 }
 
-/* publications on the CV render as a flat list (no cards) */
+/* publications on the CV render as a flat list (no cards); position:relative
+   contains any stretched-link ::after so it can never cover the page */
 .nw-cv .nw-cite {
+  position: relative;
   padding: 0.7rem 0;
   border-bottom: 1px solid var(--nw-border);
 }
@@ -1407,8 +1412,11 @@ body:has(.nw-cv) #title-block-header {
   .nw-cv-section > h3 {
     break-after: avoid;
   }
+}
 
-  @page {
-    margin: 1.5cm;
-  }
+/* Page margins for print/save-as-PDF. Kept at the top level: @page only
+   applies to paged media anyway, and Chromium ignores @page rules nested
+   inside @media print, which left printed PDFs with no margins at all. */
+@page {
+  margin: 1.5cm;
 }

--- a/index.qmd
+++ b/index.qmd
@@ -406,7 +406,7 @@ include-after-body:
     <div class="nw-cta-card">
       <h2>Open to Opportunities</h2>
       <p>I'm currently looking for <strong>data scientist</strong> or <strong>GIS analyst</strong> roles.<br>Let's connect and discuss how I can help your team.</p>
-      <div class="nw-btns"><a class="nw-btn nw-btn-primary nw-btn-resume" href="uploads/resume.pdf" target="_blank" rel="noopener">Download Resume</a></div>
+      <div class="nw-btns"><a class="nw-btn nw-btn-primary nw-btn-resume" href="uploads/resume.pdf" target="_blank" rel="noopener">Download Resume</a><a class="nw-btn nw-btn-primary nw-btn-resume" href="/cv">View Full CV</a></div>
     </div>
   </div>
 </section>

--- a/index.qmd
+++ b/index.qmd
@@ -406,7 +406,7 @@ include-after-body:
     <div class="nw-cta-card">
       <h2>Open to Opportunities</h2>
       <p>I'm currently looking for <strong>data scientist</strong> or <strong>GIS analyst</strong> roles.<br>Let's connect and discuss how I can help your team.</p>
-      <div class="nw-btns"><a class="nw-btn nw-btn-primary nw-btn-resume" href="uploads/resume.pdf" target="_blank" rel="noopener">Download Resume</a><a class="nw-btn nw-btn-primary nw-btn-resume" href="/cv">View Full CV</a></div>
+      <div class="nw-btns"><a class="nw-btn nw-btn-primary nw-btn-resume" href="uploads/resume.pdf" target="_blank" rel="noopener">Download Resume</a><a class="nw-btn nw-btn-primary nw-btn-resume" href="/cv.html">View Full CV</a></div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary

- **CV header hijacked by an invisible link / unclickable buttons**: the publications stretched-link rule (`.nw-cite-title a::after { position: absolute; inset: 0 }`) was unscoped. On the CV page the `.nw-cite` rows have no positioned ancestor, so each citation's `::after` expanded to cover the entire page; the topmost one (the Peer Review referee report entry) intercepted every click at the top of the page, including the **Print / Save as PDF** and **One-page Résumé** buttons. The stretched link is now scoped to `.nw-cites` (the publications card listings, which do have `position: relative` containers), and `.nw-cv .nw-cite` gets `position: relative` as containment insurance.
- **No print margins on Cmd+P**: the `@page { margin: 1.5cm }` rule was nested inside `@media print`, which Chromium ignores. Hoisted it to the top level of the stylesheet (`@page` only applies to paged media anyway), so printed/saved PDFs get proper 1.5cm margins.
- **View Full CV button**: added next to Download Resume in the "Open to Opportunities" section on the home page, using the same `nw-btn nw-btn-primary nw-btn-resume` styling, linking to `/cv`.

## Testing

- Compiled `assets/theme.scss` with dart-sass: no errors, and `@page` lands at the top level of the emitted CSS.
- Verified both stretched-card usages (home `#featured-pubs` and `/publications` `#all-pubs`) are wrapped in `.nw-cites`, so card behavior there is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183sUE8mpXaRvQA5XmtqY76

---
_Generated by [Claude Code](https://claude.ai/code/session_0183sUE8mpXaRvQA5XmtqY76)_