### PR TITLE
Fix CV print margins, hide print title, center share on listing pages

### DIFF
--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -1365,6 +1365,13 @@ body:has(.nw-cv) #title-block-header {
     display: none !important;
   }
 
+  /* Drop the Quarto page title block ("Curriculum Vitae" + description) from
+     the printed CV only — it stays on screen. The heading is redundant on a
+     saved PDF, where the person's name already leads the document. */
+  body:has(.nw-cv) #title-block-header {
+    display: none !important;
+  }
+
   html,
   body {
     background: #fff !important;
@@ -1374,7 +1381,10 @@ body:has(.nw-cv) #title-block-header {
   .nw-cv {
     max-width: none;
     margin: 0;
-    padding: 0;
+    /* Left/right page margins are applied here as horizontal padding rather
+       than via @page, so they survive on every printed page even when the
+       browser zeroes out @page side margins. Top/bottom come from @page. */
+    padding: 0 1.5cm;
   }
 
   .nw-cv-name,
@@ -1416,7 +1426,22 @@ body:has(.nw-cv) #title-block-header {
 
 /* Page margins for print/save-as-PDF. Kept at the top level: @page only
    applies to paged media anyway, and Chromium ignores @page rules nested
-   inside @media print, which left printed PDFs with no margins at all. */
+   inside @media print, which left printed PDFs with no margins at all.
+
+   Only top/bottom margins are set here. Some browsers drop the left/right
+   @page margins (or the user's dialog zeroes them), which left printed CVs
+   flush against the left and right edges. The left/right margins are instead
+   applied as horizontal padding on .nw-cv above, so they hold on every page. */
 @page {
-  margin: 1.5cm;
+  margin: 1.5cm 0;
+}
+
+/* Social share row: the extension drops the block into the "body-content" grid
+   column. That column is centered on article pages (individual projects, blog
+   posts) but sits left of center on the full-width listing pages (/projects,
+   /awards, /blog), leaving the buttons off-center there. Span the whole grid so
+   the extension's justify-content:center lands the row centered on every layout.
+   Higher specificity than Quarto's `.page-columns > *` rule so it wins. */
+.page-columns > .social-share {
+  grid-column: screen-start / screen-end;
 }


### PR DESCRIPTION
## Summary

Three fixes to `assets/theme.scss`:

1. **CV print left/right margins.** The left/right page margins are now applied as horizontal `padding` on `.nw-cv` instead of relying solely on `@page`. Some browsers (or a user's print dialog) drop the left/right `@page` margins, leaving the printed CV flush against the page edges. Padding holds on every printed page. `@page` now sets only top/bottom margins (`margin: 1.5cm 0`).
2. **Hide the title block when printing the CV.** The Quarto page title block ("Curriculum Vitae" + description) is hidden in `@media print` only (scoped to `body:has(.nw-cv)`), so it stays on screen but is dropped from the saved PDF, where the person's name already leads the document.
3. **Center the social-share row on listing pages.** The share block spans the full `page-columns` grid (`grid-column: screen-start / screen-end`) so the extension's `justify-content: center` lands it centered on the full-width listing pages (`/projects`, `/awards`, `/blog`), matching the article pages where it was already centered.

## Verification

Reproduced and measured with the pre-installed headless Chromium against a local mirror of the live site (real compiled CSS):

- **Margins:** printed CV body content lands at 1.5cm on all four sides across all 9 pages; the padding approach yields left/right = 1.5cm with no doubling.
- **Title:** the "Curriculum Vitae" heading and description are removed from the printed body (only the browser's own header/footer furniture remains, which is a separate print setting).
- **Share centering:** listing page share row moves from off-center (center ≈ 560px vs page center 633px) to centered (633px = 633px), matching article pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YEn5ZL3wXEv2FTpe2XQuc

---
_Generated by [Claude Code](https://claude.ai/code/session_019YEn5ZL3wXEv2FTpe2XQuc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved CV print and PDF formatting.
  * Preserved consistent left and right margins across printed pages.
  * Hid the CV title block when printing.
  * Centered the social sharing row across supported layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->