### PR TITLE
Add Quarto logo to footer credit line

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -116,7 +116,7 @@ website:
       </div>
       </div>
       <div class="nw-footer-bottom">
-      <div>© 2026 Noah Weidig · Built with <a href="https://quarto.org">Quarto</a>.</div>
+      <div>© 2026 Noah Weidig · Built with <a href="https://quarto.org" class="nw-quarto-credit"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4l16 8l-16 8z"/></svg>Quarto</a>. All Rights Reserved.</div>
       </div>
       </div>
 

--- a/assets/site.css
+++ b/assets/site.css
@@ -463,6 +463,19 @@ img.nw-detail-hero {
   font-size: 0.85rem;
 }
 
+.nw-footer-bottom .nw-quarto-credit {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: inherit;
+}
+
+.nw-footer-bottom .nw-quarto-credit svg {
+  width: 0.9rem;
+  height: 0.9rem;
+  flex: none;
+}
+
 @media (max-width: 900px) {
   .nw-footer-grid {
     grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
## Summary
- Add a small inline monochrome SVG icon before "Quarto" in the footer credit line
- Icon uses `stroke="currentColor"` so it matches the surrounding text color in both light and dark themes
- Append "All Rights Reserved." to the footer copyright line

## Test plan
- [ ] Visually confirm the footer renders correctly in light and dark mode (Quarto not installed in this sandbox, so unable to render/preview locally)

---
_Generated by [Claude Code](https://claude.ai/code/session_018MjPLbpfLRjxP6LJpR7y8w)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the site footer’s Quarto credit with an inline Quarto logo.
  * Improved logo alignment, spacing, sizing, and color consistency with the footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->