### PR TITLE
Use actual Quarto logo mark in footer credit

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -116,7 +116,7 @@ website:
       </div>
       </div>
       <div class="nw-footer-bottom">
-      <div>© 2026 Noah Weidig · Built with <a href="https://quarto.org" class="nw-quarto-credit"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4l16 8l-16 8z"/></svg>Quarto</a>. All Rights Reserved.</div>
+      <div>© 2026 Noah Weidig · Built with <a href="https://quarto.org" class="nw-quarto-credit"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" aria-hidden="true"><path d="M12 12L12 4A8 8 0 0 1 20 12Z"/><path d="M12 12L20 12A8 8 0 0 1 12 20Z"/><path d="M12 12L12 20A8 8 0 0 1 4 12Z"/><path d="M10.6 10.6L2.6 10.6A8 8 0 0 1 10.6 2.6Z"/></svg>Quarto</a>. All Rights Reserved.</div>
       </div>
       </div>
 


### PR DESCRIPTION
## Summary

The previous footer "Built with Quarto" credit used a generic triangle/play glyph instead of the real Quarto logo. This replaces it with the actual Quarto mark — a quartered circle with the top-left quadrant offset — drawn as inline SVG.

- Uses `stroke="currentColor"`, so the mark matches the footer text color automatically in both light and dark modes.
- Existing `.nw-quarto-credit` CSS (color inheritance + sizing) is unchanged and already covers the new SVG.

## Changes
- `_quarto.yml`: swap the triangle `<path>` for the four-quadrant Quarto logo paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019V4hHkHAkW8PRGQ7m11ffy)_