### PR TITLE
Hide package hex icons from the R packages post TOC

### DIFF
--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -1070,6 +1070,15 @@ body {
   scroll-margin-top: 4.5rem;
 }
 
+/* Package hex logos are placed inline in section headings (e.g. `### dplyr
+   <img ...>`). Quarto copies each heading's markup into the table-of-contents
+   sidebar, which pulled those hex icons into the TOC "legend". Hide images in
+   the TOC so only the package names show there. */
+#TOC img,
+nav[role="doc-toc"] img {
+  display: none;
+}
+
 @media (max-width: 640px) {
   .nw-section { padding: 3rem 0; }
 }


### PR DESCRIPTION
## Problem

In the "My Favorite R Packages" blog post, the package hex logos are placed inline in section headings (e.g. `### dplyr <img ...>`). Quarto copies each heading's markup into the table-of-contents sidebar, so those hex icons were also appearing in the TOC "legend".

## Fix

Added a CSS rule in `assets/theme.scss` hiding images within the TOC (`#TOC img`, `nav[role="doc-toc"] img`), so only the package names show in the sidebar while the icons remain in the headings themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCkRhhWqVHHtciE1i4kYHH

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCkRhhWqVHHtciE1i4kYHH)_