### PR TITLE
Morph mobile hamburger into an X when expanded

### DIFF
--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -1126,12 +1126,11 @@ nav[role="doc-toc"] img {
 
   /* ----- Hamburger that morphs into an X when expanded (no layout shift) ----- */
   .navbar .navbar-toggler .navbar-toggler-icon {
-    background-image: none;
     position: relative;
     width: 1.4rem;
     height: 1.4rem;
     display: inline-block;
-    /* middle bar */
+    /* middle bar (the shorthand also clears Bootstrap's default icon image) */
     background: linear-gradient(var(--nw-fg), var(--nw-fg)) center / 100% 2px no-repeat;
     transition: background 0.2s ease;
   }

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -1123,6 +1123,46 @@ nav[role="doc-toc"] img {
   .navbar .navbar-brand img {
     display: none;
   }
+
+  /* ----- Hamburger that morphs into an X when expanded (no layout shift) ----- */
+  .navbar .navbar-toggler .navbar-toggler-icon {
+    background-image: none;
+    position: relative;
+    width: 1.4rem;
+    height: 1.4rem;
+    display: inline-block;
+    /* middle bar */
+    background: linear-gradient(var(--nw-fg), var(--nw-fg)) center / 100% 2px no-repeat;
+    transition: background 0.2s ease;
+  }
+
+  .navbar .navbar-toggler .navbar-toggler-icon::before,
+  .navbar .navbar-toggler .navbar-toggler-icon::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--nw-fg);
+    border-radius: 2px;
+    transition: transform 0.2s ease, top 0.2s ease;
+  }
+
+  .navbar .navbar-toggler .navbar-toggler-icon::before { top: 0.25rem; }
+  .navbar .navbar-toggler .navbar-toggler-icon::after  { top: 1.05rem; }
+
+  /* Expanded → the two outer bars rotate into an X, middle bar fades. */
+  .navbar .navbar-toggler[aria-expanded="true"] .navbar-toggler-icon {
+    background-image: none;
+  }
+  .navbar .navbar-toggler[aria-expanded="true"] .navbar-toggler-icon::before {
+    top: 0.65rem;
+    transform: rotate(45deg);
+  }
+  .navbar .navbar-toggler[aria-expanded="true"] .navbar-toggler-icon::after {
+    top: 0.65rem;
+    transform: rotate(-45deg);
+  }
 }
 
 /* very narrow screens: shrink the site title so it isn't cut off */


### PR DESCRIPTION
## What

On mobile (`max-width: 991.98px`), the navbar hamburger now animates into an X when the menu is expanded, matching how chartifyr does it.

## How

Replaces the default Bootstrap `navbar-toggler-icon` SVG with three CSS bars (middle bar via `linear-gradient`, top/bottom via `::before`/`::after`). When `aria-expanded="true"`, the two outer bars rotate ±45° into an X and the middle bar fades out — no layout shift. Bar color uses the existing `--nw-fg` variable so it works in both light and dark themes.

Single file changed: `assets/theme.scss` (added to the existing mobile navbar `@media` block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T47Zs7jyWib4YgwcDwP1vS

---
_Generated by [Claude Code](https://claude.ai/code/session_01T47Zs7jyWib4YgwcDwP1vS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the mobile navigation toggle animation.
  * The menu icon now transforms into a clear “X” when the navigation menu is expanded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->