### PR TITLE
Two-column hero layout (text left, image right) on wider screens

### DIFF
--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -337,6 +337,47 @@ body {
   border-color: var(--nw-primary);
 }
 
+/* ============ hero: two-column (text left, image right) on wider screens ============ */
+/* mobile stays the centered stack above; >=768px splits into text | avatar */
+@media (min-width: 768px) {
+  #hero {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    column-gap: 3rem;
+    align-items: center;
+    text-align: left;
+    max-width: 72rem;
+    margin: 0 auto;
+  }
+
+  /* avatar occupies the right column, spanning all text rows */
+  #hero .nw-avatar {
+    grid-column: 2;
+    grid-row: 1 / -1;
+    align-self: center;
+    width: 18rem;
+    height: 18rem;
+    margin-bottom: 0;
+  }
+
+  /* text content flows into the left column, left-aligned */
+  #hero .nw-status {
+    margin-bottom: 1rem;
+  }
+
+  #hero .nw-socials,
+  #hero .nw-btns {
+    justify-content: flex-start;
+  }
+}
+
+@media (min-width: 992px) {
+  #hero .nw-avatar {
+    width: 22rem;
+    height: 22rem;
+  }
+}
+
 /* ============ stats ============ */
 #stats .nw-stats {
   display: grid;


### PR DESCRIPTION
## Summary

Reworks the hero section so that on wider screens (≥768px) the text sits on the left and the avatar image sits on the right, matching the reference example. The centered stacked mobile layout is unchanged.

## Changes

- `assets/theme.scss`: added a `min-width: 768px` grid layout for `#hero` (`1fr auto`, text left-aligned). Avatar moves to the right column spanning all text rows, enlarged to 18rem (22rem at ≥992px). Socials and buttons left-align; mobile (<768px) keeps the existing centered stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrkWqSSXCPXL4sNbH6skyu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the hero section’s responsive layout on tablets and larger screens.
  * Hero text now appears alongside the avatar, with optimized alignment and sizing.
  * Avatar size increases further on larger desktop displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->