### PR TITLE
Restructure hero into explicit text/portrait columns

### DIFF
--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -337,30 +337,54 @@ body {
   border-color: var(--nw-primary);
 }
 
-/* ============ hero: two-column (text left, image right) on wider screens ============ */
-/* mobile stays the centered stack above; >=768px splits into text | avatar */
+/* ============ hero: two-column (text left, portrait right) on wider screens ============ */
+/* mobile: centered stack (portrait first); >=768px: text | portrait split */
+.nw-hero-inner {
+  max-width: 72rem;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: center;
+  gap: 2rem;
+}
+
+.nw-hero-media {
+  position: relative;
+  flex-shrink: 0;
+}
+
+/* soft glow halo behind the portrait */
+.nw-hero-media::before {
+  content: "";
+  position: absolute;
+  inset: -15%;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--nw-hero-glow), transparent 70%);
+  z-index: 0;
+}
+
+.nw-hero-media .nw-avatar {
+  position: relative;
+  z-index: 1;
+  display: block;
+  margin-bottom: 0;
+}
+
 @media (min-width: 768px) {
+  .nw-hero-inner {
+    flex-direction: row;
+    justify-content: space-between;
+    gap: 3rem;
+  }
+
   #hero {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    column-gap: 3rem;
-    align-items: center;
     text-align: left;
-    max-width: 72rem;
-    margin: 0 auto;
   }
 
-  /* avatar occupies the right column, spanning all text rows */
-  #hero .nw-avatar {
-    grid-column: 2;
-    grid-row: 1 / -1;
-    align-self: center;
-    width: 18rem;
-    height: 18rem;
-    margin-bottom: 0;
+  #hero .nw-hero-text {
+    max-width: 34rem;
   }
 
-  /* text content flows into the left column, left-aligned */
   #hero .nw-status {
     margin-bottom: 1rem;
   }
@@ -368,6 +392,11 @@ body {
   #hero .nw-socials,
   #hero .nw-btns {
     justify-content: flex-start;
+  }
+
+  #hero .nw-avatar {
+    width: 18rem;
+    height: 18rem;
   }
 }
 

--- a/index.qmd
+++ b/index.qmd
@@ -87,7 +87,8 @@ include-after-body:
 
 ```{=html}
 <section id="hero">
-  <img class="nw-avatar" src="assets/media/authors/me.webp" alt="Noah Weidig" width="700" height="700" fetchpriority="high" decoding="async">
+  <div class="nw-hero-inner">
+  <div class="nw-hero-text">
   <div><span class="nw-status">Open to opportunities</span></div>
   <h1><span class="nw-hi">— Hi, I'm —</span><span class="nw-name">Noah Weidig</span></h1>
   <div class="nw-role">GIS Analyst • Data Scientist</div>
@@ -101,6 +102,11 @@ include-after-body:
   <div class="nw-btns">
     <a class="nw-btn nw-btn-primary" href="#projects">View My Work ↓</a>
     <a class="nw-btn nw-btn-ghost" href="#contact">Get In Touch <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 7l9 6l9 -6"/></svg></a>
+  </div>
+  </div>
+  <div class="nw-hero-media">
+    <img class="nw-avatar" src="assets/media/authors/me.webp" alt="Noah Weidig" width="700" height="700" fetchpriority="high" decoding="async">
+  </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
The hero section split into two columns via CSS grid auto-placement, which stranded the role line and social icons under the avatar and left large vertical gaps between the status badge and the name.

This restructures the hero markup into explicit containers:
- `.nw-hero-inner` wraps the section content
- `.nw-hero-text` (left column): status badge, greeting + name, role, typed tagline, social icons, CTA buttons
- `.nw-hero-media` (right column): portrait, vertically centered, with a soft radial glow halo behind it

The old grid media-query hack in `assets/theme.scss` is replaced with a flex layout: side-by-side text | portrait at ≥768px, and a centered portrait-first stack on mobile (via `column-reverse`).

## Changes
- `index.qmd`: wrap hero content in `.nw-hero-inner` / `.nw-hero-text` / `.nw-hero-media`
- `assets/theme.scss`: replace grid auto-placement layout with explicit flex columns; add glow halo behind portrait

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyizHUvGEhGxWW4qmMWoM5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyizHUvGEhGxWW4qmMWoM5)_