### PR TITLE
Redesign hero heading and enlarge hero text on desktop

### DIFF
--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -234,6 +234,11 @@ body {
   color: var(--nw-fg);
 }
 
+#hero h1 .nw-name .nw-accent {
+  color: var(--nw-primary);
+  -webkit-text-fill-color: var(--nw-primary);
+}
+
 #hero .nw-role {
   font-size: 1.15rem;
   color: var(--nw-muted);
@@ -382,7 +387,7 @@ body {
   }
 
   #hero .nw-hero-text {
-    max-width: 34rem;
+    max-width: 38rem;
   }
 
   #hero .nw-status {
@@ -404,6 +409,32 @@ body {
   #hero .nw-avatar {
     width: 22rem;
     height: 22rem;
+  }
+
+  /* fill the dead space between text and portrait: bigger type, narrower row */
+  .nw-hero-inner {
+    max-width: 66rem;
+  }
+
+  #hero h1 {
+    font-size: clamp(3.25rem, 5vw, 4.75rem);
+  }
+
+  #hero h1 .nw-hi {
+    font-size: 1.2rem;
+  }
+
+  #hero .nw-role {
+    font-size: 1.4rem;
+  }
+
+  #hero .nw-type {
+    font-size: 1.6rem;
+    min-height: 2.6rem;
+  }
+
+  #hero .nw-hero-text {
+    max-width: 42rem;
   }
 }
 

--- a/index.qmd
+++ b/index.qmd
@@ -90,7 +90,7 @@ include-after-body:
   <div class="nw-hero-inner">
   <div class="nw-hero-text">
   <div><span class="nw-status">Open to opportunities</span></div>
-  <h1><span class="nw-hi">— Hi, I'm —</span><span class="nw-name">Noah Weidig</span></h1>
+  <h1><span class="nw-hi">Welcome to my website!</span><span class="nw-name">Hello, My<br>Name's <span class="nw-accent">Noah</span>.</span></h1>
   <div class="nw-role">GIS Analyst • Data Scientist</div>
   <div class="nw-type">I build <span class="nw-typed" data-strings='["geospatial analyses","remote sensing workflows","data-driven insights","GIS applications"]'></span><span class="nw-caret">&nbsp;</span></div>
   <div class="nw-socials">


### PR DESCRIPTION
## Summary
- Replace the "— Hi, I'm —" eyebrow with "Welcome to my website!"
- Change the hero heading to "Hello, My<br>Name's Noah." with only "Noah" in the accent blue (`--nw-primary`)
- Enlarge hero typography on desktop (≥992px): bigger heading (`clamp(3.25rem, 5vw, 4.75rem)`), larger role line and typed text, wider text column (42rem)
- Tighten `.nw-hero-inner` max-width to 66rem at ≥992px so the portrait sits closer to the text and the blank gap between them shrinks

## Files changed
- `index.qmd` — hero heading markup
- `assets/theme.scss` — accent color for "Noah", desktop hero type scale, hero row width

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyV4RdzC3mDgL3jp8YHmdH

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyV4RdzC3mDgL3jp8YHmdH)_