### PR TITLE
Replace Leaflet map with MapLibre globe fly-in to Orlando

### DIFF
--- a/assets/theme-dark.scss
+++ b/assets/theme-dark.scss
@@ -62,33 +62,32 @@ $input-bg: #13131a;
   color: var(--nw-primary) !important;
 }
 
-/* Leaflet chrome ships light-only; restyle controls and popups for dark */
-#map .leaflet-container {
-  background: #0a0a0f;
-}
-
-#map .leaflet-control-zoom a {
+/* MapLibre chrome ships light-only; restyle controls and attribution for dark */
+#map .maplibregl-ctrl-group {
   background: #13131a;
-  color: #e5e7eb;
-  border-color: #26262f;
 }
 
-#map .leaflet-control-zoom a:hover {
+#map .maplibregl-ctrl-group button + button {
+  border-top-color: #26262f;
+}
+
+#map .maplibregl-ctrl-group button:hover {
   background: #1d1d26;
 }
 
-#map .leaflet-control-attribution {
+#map .maplibregl-ctrl button .maplibregl-ctrl-icon {
+  filter: invert(1) hue-rotate(180deg);
+}
+
+#map .maplibregl-ctrl-attrib {
   background: rgba(19, 19, 26, 0.85);
   color: #9ca3af;
 }
 
-#map .leaflet-control-attribution a {
+#map .maplibregl-ctrl-attrib a {
   color: #8fcaff;
 }
 
-#map .leaflet-popup-content-wrapper,
-#map .leaflet-popup-tip {
-  background: #13131a;
-  color: #e5e7eb;
-  box-shadow: 0 3px 14px rgba(0, 0, 0, 0.6);
+#map .maplibregl-ctrl-attrib-button {
+  filter: invert(1);
 }

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -1083,12 +1083,94 @@ body {
   color: #ef4444;
 }
 
-/* ============ map ============ */
+/* ============ map (MapLibre globe) ============ */
 #map .nw-map {
   height: 26rem;
   border-radius: 1rem;
   border: 1px solid var(--nw-border);
   overflow: hidden;
+  /* Outer space behind the transparent globe canvas: deep-space base plus
+     repeating starfield layers. Space stays dark in both color modes. */
+  background-color: #05070d;
+  background-image:
+    radial-gradient(1px 1px at 25px 35px, rgba(255, 255, 255, 0.9) 50%, transparent 51%),
+    radial-gradient(1px 1px at 130px 90px, rgba(255, 255, 255, 0.55) 50%, transparent 51%),
+    radial-gradient(1.5px 1.5px at 210px 160px, rgba(255, 255, 255, 0.8) 50%, transparent 51%),
+    radial-gradient(1px 1px at 70px 200px, rgba(214, 230, 255, 0.6) 50%, transparent 51%),
+    radial-gradient(1.5px 1.5px at 300px 60px, rgba(255, 244, 214, 0.7) 50%, transparent 51%),
+    radial-gradient(ellipse at 50% 40%, #131c33 0%, rgba(19, 28, 51, 0) 70%);
+  background-size: 260px 260px, 340px 340px, 420px 420px, 300px 300px, 380px 380px, 100% 100%;
+  background-repeat: repeat, repeat, repeat, repeat, repeat, no-repeat;
+}
+
+/* Pulsing marker on Orlando */
+#map .nw-pulse {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--nw-primary);
+  border: 2px solid #ffffff;
+  position: relative;
+}
+
+#map .nw-pulse::before {
+  content: "";
+  position: absolute;
+  inset: -3px;
+  border-radius: 50%;
+  background: var(--nw-primary);
+  opacity: 0.6;
+  animation: nw-ping 2s cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+
+@keyframes nw-ping {
+  0% { transform: scale(1); opacity: 0.6; }
+  80%, 100% { transform: scale(3); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #map .nw-pulse::before {
+    animation: none;
+  }
+}
+
+/* Marker popup restyled to match the site card look in both color modes */
+#map .maplibregl-popup-content {
+  font-family: inherit;
+  background: var(--nw-card);
+  color: var(--nw-fg);
+  border: 1px solid var(--nw-border);
+  border-radius: 0.6rem;
+  padding: 0.55rem 0.85rem;
+  box-shadow: 0 3px 14px rgba(0, 0, 0, 0.25);
+}
+
+#map .maplibregl-popup-content code {
+  font-size: 0.8rem;
+  background: var(--nw-chip);
+  color: var(--nw-fg);
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.3rem;
+}
+
+#map .maplibregl-popup-anchor-bottom .maplibregl-popup-tip,
+#map .maplibregl-popup-anchor-bottom-left .maplibregl-popup-tip,
+#map .maplibregl-popup-anchor-bottom-right .maplibregl-popup-tip {
+  border-top-color: var(--nw-card);
+}
+
+#map .maplibregl-popup-anchor-top .maplibregl-popup-tip,
+#map .maplibregl-popup-anchor-top-left .maplibregl-popup-tip,
+#map .maplibregl-popup-anchor-top-right .maplibregl-popup-tip {
+  border-bottom-color: var(--nw-card);
+}
+
+#map .maplibregl-popup-anchor-left .maplibregl-popup-tip {
+  border-right-color: var(--nw-card);
+}
+
+#map .maplibregl-popup-anchor-right .maplibregl-popup-tip {
+  border-left-color: var(--nw-card);
 }
 
 /* ============ CTA card ============ */

--- a/index.qmd
+++ b/index.qmd
@@ -30,44 +30,119 @@ include-after-body:
   - text: |
       <script src="assets/home.js"></script>
       <script>
-        // Leaflet is only needed for the map at the very bottom of the page,
+        // MapLibre is only needed for the globe at the very bottom of the page,
         // so defer fetching its CSS/JS (and the map tiles) until the map is
         // about to scroll into view instead of paying for it on page load.
+        // The map starts as a globe in space on the far side of the world;
+        // once the section is actually visible it spins around the globe and
+        // dives down into Orlando.
         (function () {
           var mapEl = document.getElementById('nw-map');
           if (!mapEl) return;
+          var ORLANDO = [-81.3789, 28.5384];
           var loaded = false;
+          var nwMap = null;
+          var mapReady = false;
+          var flown = false;
+          var wantFly = false;
+          var nwMarker = null;
+          var nwPopup = null;
+          // Marker + popup stay hidden until the fly-in has landed on Orlando
+          function nwShowMarker() {
+            if (nwMarker) { nwMarker.addTo(nwMap); nwMarker = null; }
+            if (nwPopup) { nwPopup.addTo(nwMap); nwPopup = null; }
+          }
+          function nwStyle() {
+            var style = document.body.classList.contains('quarto-dark') ||
+              document.documentElement.classList.contains('quarto-dark')
+              ? 'dark_all' : 'rastertiles/voyager';
+            return {
+              version: 8,
+              projection: { type: 'globe' },
+              // Atmosphere halo while in "space", fading out once zoomed in
+              sky: { 'atmosphere-blend': ['interpolate', ['linear'], ['zoom'], 0, 1, 6, 1, 8, 0] },
+              sources: {
+                carto: {
+                  type: 'raster',
+                  tiles: ['a', 'b', 'c', 'd'].map(function (s) {
+                    return 'https://' + s + '.basemaps.cartocdn.com/' + style + '/{z}/{x}/{y}.png';
+                  }),
+                  tileSize: 256,
+                  attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>'
+                }
+              },
+              // No background layer: the canvas stays transparent around the
+              // globe so the CSS starfield behind it shows through.
+              layers: [{ id: 'carto', type: 'raster', source: 'carto' }]
+            };
+          }
+          function nwFly() {
+            if (flown) return;
+            if (!mapReady) { wantFly = true; return; }
+            flown = true;
+            if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+              nwMap.jumpTo({ center: ORLANDO, zoom: 12.2 });
+              nwShowMarker();
+              return;
+            }
+            // Stage 1: spin the globe most of the way around while easing in…
+            nwMap.easeTo({
+              center: [ORLANDO[0] + 55, 12],
+              zoom: 1.6,
+              duration: 3000,
+              easing: function (t) { return t; },
+              essential: true
+            });
+            nwMap.once('moveend', function () {
+              // …stage 2: finish the spin and dive down into Orlando.
+              nwMap.flyTo({ center: ORLANDO, zoom: 12.2, duration: 5200, essential: true });
+              nwMap.once('moveend', nwShowMarker);
+            });
+          }
           function nwInitMap() {
-            var nwMap = L.map('nw-map', { scrollWheelZoom: false }).setView([29.6436, -82.3549], 15);
-            var nwTiles = null;
-            var nwTileStyle = null;
+            nwMap = new maplibregl.Map({
+              container: 'nw-map',
+              style: nwStyle(),
+              // Opposite side of the world from Orlando, zoomed all the way out
+              center: [ORLANDO[0] + 180, -ORLANDO[1]],
+              zoom: 0.6,
+              attributionControl: { compact: true }
+            });
+            nwMap.scrollZoom.disable();
+            nwMap.addControl(new maplibregl.NavigationControl({ showCompass: false }));
+            var dot = document.createElement('div');
+            dot.className = 'nw-pulse';
+            nwMarker = new maplibregl.Marker({ element: dot }).setLngLat(ORLANDO);
+            nwPopup = new maplibregl.Popup({ offset: 18, closeButton: false, closeOnClick: false, focusAfterOpen: false })
+              .setLngLat(ORLANDO)
+              .setHTML('<b>Orlando, Florida</b><br><code>28.5384&deg; N, 81.3789&deg; W</code>');
+            var nwMapStyle = null;
             function nwSyncMapTheme() {
               var style = document.body.classList.contains('quarto-dark') ||
                 document.documentElement.classList.contains('quarto-dark')
                 ? 'dark_all' : 'rastertiles/voyager';
-              if (style === nwTileStyle) return;
-              nwTileStyle = style;
-              if (nwTiles) nwMap.removeLayer(nwTiles);
-              nwTiles = L.tileLayer('https://{s}.basemaps.cartocdn.com/' + style + '/{z}/{x}/{y}{r}.png', {
-                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>'
-              }).addTo(nwMap);
+              if (style === nwMapStyle) return;
+              nwMapStyle = style;
+              nwMap.setStyle(nwStyle());
             }
-            nwSyncMapTheme();
+            nwMapStyle = nwStyle().sources.carto.tiles[0].indexOf('dark_all') !== -1 ? 'dark_all' : 'rastertiles/voyager';
             var nwThemeWatcher = new MutationObserver(nwSyncMapTheme);
             nwThemeWatcher.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
             nwThemeWatcher.observe(document.body, { attributes: true, attributeFilter: ['class'] });
-            L.marker([29.6436, -82.3549]).addTo(nwMap)
-              .bindPopup('<b>University of Florida</b><br>School of Forest, Fisheries and Geomatic Sciences');
+            nwMap.on('load', function () {
+              mapReady = true;
+              if (wantFly) nwFly();
+            });
           }
-          function nwLoadLeaflet() {
+          function nwLoadMapLibre() {
             if (loaded) return;
             loaded = true;
             var css = document.createElement('link');
             css.rel = 'stylesheet';
-            css.href = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css';
+            css.href = 'https://unpkg.com/maplibre-gl@5.6.0/dist/maplibre-gl.css';
             document.head.appendChild(css);
             var js = document.createElement('script');
-            js.src = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js';
+            js.src = 'https://unpkg.com/maplibre-gl@5.6.0/dist/maplibre-gl.js';
             js.onload = nwInitMap;
             document.head.appendChild(js);
           }
@@ -75,11 +150,18 @@ include-after-body:
             new IntersectionObserver(function (entries, obs) {
               if (entries.some(function (e) { return e.isIntersecting; })) {
                 obs.disconnect();
-                nwLoadLeaflet();
+                nwLoadMapLibre();
               }
             }, { rootMargin: '600px' }).observe(mapEl);
+            new IntersectionObserver(function (entries, obs) {
+              if (entries.some(function (e) { return e.isIntersecting; })) {
+                obs.disconnect();
+                nwFly();
+              }
+            }, { threshold: 0.4 }).observe(mapEl);
           } else {
-            nwLoadLeaflet();
+            nwLoadMapLibre();
+            wantFly = true;
           }
         })();
       </script>


### PR DESCRIPTION
## What changed

Replaces the Leaflet "Find Me" map on the homepage with a MapLibre GL globe (true globe projection, not a flat map):

- **Globe in space**: the map opens as a round globe floating in a CSS starfield, positioned on the opposite side of the world from Orlando and zoomed all the way out.
- **Scroll-triggered fly-in**: when the section scrolls into view, the globe spins ~180° around and then dives down into Orlando (two-stage `easeTo` + `flyTo`). Respects `prefers-reduced-motion` (jumps straight to Orlando).
- **Pulsing marker**: a pulsing dot on Orlando appears only after the fly-in lands, with a popup showing `28.5384° N, 81.3789° W` in code font.
- **Theme-aware**: CARTO voyager/dark_all raster tiles still swap with the site's light/dark theme (same MutationObserver approach as before); MapLibre controls, attribution, and popup are restyled to match site variables in both modes.
- **Same lazy-load pattern**: MapLibre CSS/JS only fetched when the map nears the viewport.

Files: `index.qmd` (map script), `assets/theme.scss` (starfield, pulse marker, popup styling), `assets/theme-dark.scss` (dark control chrome — replaces the old Leaflet overrides).

Nothing else on the page was changed.

## Verification

Headless-browser screenshots confirm a round globe over the starfield mid-animation (no marker visible), landing on Orlando with pulsing marker + coordinate popup, in both light and dark modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNSDSNfN9MR8f4Nvm4M5Jd

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNSDSNfN9MR8f4Nvm4M5Jd)_