### PR TITLE
Remove open to opportunities pill from hero

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -171,7 +171,6 @@ include-after-body:
 <section id="hero">
   <div class="nw-hero-inner">
   <div class="nw-hero-text">
-  <div><span class="nw-status">Open to opportunities</span></div>
   <h1><span class="nw-hi">Welcome to my website!</span><span class="nw-name">Hello, My<br>Name's <span class="nw-accent">Noah</span>.</span></h1>
   <div class="nw-role">GIS Analyst • Data Scientist</div>
   <div class="nw-type">I build <span class="nw-typed" data-strings='["geospatial analyses","remote sensing workflows","data-driven insights","GIS applications"]'></span><span class="nw-caret">&nbsp;</span></div>


### PR DESCRIPTION
Removes the "Open to opportunities" status pill from the hero section in `index.qmd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015SVaMChF4KtN8TfxToFjEA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the “Open to opportunities” status label from the hero section.
  * The status message remains available in the page’s call-to-action section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->