### PR TITLE
Add code-window extension with theme-aware backgrounds; speed up map zoom

### DIFF
--- a/_extensions/mcanouil/code-window/LICENSE
+++ b/_extensions/mcanouil/code-window/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mickaël Canouil
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/_extensions/mcanouil/code-window/_extension.yml
+++ b/_extensions/mcanouil/code-window/_extension.yml
@@ -1,0 +1,10 @@
+title: Code Window
+author: Mickaël Canouil
+version: 1.2.1
+quarto-required: ">=1.9.36"
+contributes:
+  filters:
+    - at: pre-quarto
+      path: main.lua
+    - at: post-quarto
+      path: _modules/hotfix/typst-title-fix.lua

--- a/_extensions/mcanouil/code-window/_modules/hotfix/code-annotations.lua
+++ b/_extensions/mcanouil/code-window/_modules/hotfix/code-annotations.lua
@@ -1,0 +1,197 @@
+--- @module code-annotations
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @brief Code annotation detection, stripping, and Typst rendering helpers.
+--- Scans CodeBlock elements for inline annotation markers (e.g. # <1>, // <2>)
+--- and provides utilities for converting annotations to Typst output.
+
+-- ============================================================================
+-- LANGUAGE COMMENT CHARACTERS
+-- ============================================================================
+
+--- Map of language identifiers to their single-line comment prefix.
+--- @type table<string, string>
+local LANG_COMMENT_CHARS = {
+  r = '#',
+  python = '#',
+  lua = '--',
+  javascript = '//',
+  typescript = '//',
+  go = '//',
+  rust = '//',
+  bash = '#',
+  sh = '#',
+  zsh = '#',
+  fish = '#',
+  c = '//',
+  cpp = '//',
+  cxx = '//',
+  cc = '//',
+  cs = '//',
+  java = '//',
+  scala = '//',
+  kotlin = '//',
+  swift = '//',
+  objc = '//',
+  php = '//',
+  ruby = '#',
+  perl = '#',
+  julia = '#',
+  haskell = '--',
+  elm = '--',
+  clojure = ';',
+  scheme = ';',
+  lisp = ';',
+  racket = ';',
+  erlang = '%%',
+  elixir = '#',
+  fortran = '!',
+  matlab = '%%',
+  ada = '--',
+  sql = '--',
+  plsql = '--',
+  tsql = '--',
+  mysql = '--',
+  sqlite = '--',
+  postgresql = '--',
+  vb = "'",
+  vbnet = "'",
+  fsharp = '//',
+  stata = '//',
+  yaml = '#',
+  toml = '#',
+  make = '#',
+  cmake = '#',
+  dockerfile = '#',
+  powershell = '#',
+  nix = '#',
+  zig = '//',
+  dart = '//',
+  groovy = '//',
+  d = '//',
+  nim = '#',
+  crystal = '#',
+  v = '//',
+  odin = '//',
+  mojo = '#',
+}
+
+-- ============================================================================
+-- ANNOTATION RESOLUTION
+-- ============================================================================
+
+--- Escape a string for use in a Lua pattern.
+--- @param s string
+--- @return string
+local function escape_pattern(s)
+  return s:gsub('([%(%)%.%%%+%-%*%?%[%]%^%$])', '%%%1')
+end
+
+--- Resolve annotations in a CodeBlock element.
+--- Scans each line for a trailing annotation marker (e.g. # <1>) using the
+--- language's comment prefix. Strips the marker from the code text and returns
+--- the cleaned text along with an annotations table.
+--- @param block pandoc.CodeBlock
+--- @return string cleaned_text The code with annotation markers removed
+--- @return table|nil annotations Maps line numbers (int) to annotation numbers (int), or nil if none found
+local function resolve_annotations(block)
+  if not block.classes or #block.classes == 0 then
+    return block.text, nil
+  end
+
+  local lang = block.classes[1]:lower()
+  local comment = LANG_COMMENT_CHARS[lang] or '#'
+
+  local escaped_comment = escape_pattern(comment)
+  local pattern = '^(.-)%s*' .. escaped_comment .. '%s*<%s*(%d+)%s*>%s*$'
+
+  local annotations = {}
+  local lines = {}
+  local found = false
+
+  local line_num = 0
+  for line in (block.text .. '\n'):gmatch('([^\n]*)\n') do
+    line_num = line_num + 1
+    local content, annot_num = line:match(pattern)
+    if annot_num then
+      found = true
+      annotations[line_num] = tonumber(annot_num)
+      table.insert(lines, content)
+    else
+      table.insert(lines, line)
+    end
+  end
+
+  if not found then
+    return block.text, nil
+  end
+
+  return table.concat(lines, '\n'), annotations
+end
+
+-- ============================================================================
+-- TYPST CONVERSION HELPERS
+-- ============================================================================
+
+--- Convert an annotations table to a Typst dictionary literal.
+--- Keys are stringified line numbers, values are annotation numbers.
+--- Example output: (1: 2, 3: 1)
+--- @param annotations table<int, int> Line number to annotation number mapping
+--- @return string Typst dictionary literal
+local function annotations_to_typst_dict(annotations)
+  local pairs_list = {}
+  local keys = {}
+  for k in pairs(annotations) do
+    table.insert(keys, k)
+  end
+  table.sort(keys)
+  for _, line_num in ipairs(keys) do
+    table.insert(pairs_list,
+      string.format('"%d": %d', line_num, annotations[line_num]))
+  end
+  return '(' .. table.concat(pairs_list, ', ') .. ')'
+end
+
+--- Check whether a block is an OrderedList that looks like an annotation list.
+--- Annotation lists are OrderedLists immediately following a code block,
+--- where each item corresponds to an annotation number.
+--- @param block pandoc.Block
+--- @return boolean
+local function is_annotation_ordered_list(block)
+  return block and block.t == 'OrderedList'
+end
+
+--- Convert an OrderedList to Typst annotation item RawBlocks.
+--- Each list item becomes a #code-window-annotation-item(block-id, n)[...] call.
+--- @param ol pandoc.OrderedList The ordered list to convert
+--- @param wrapper_prefix string Prefix for the Typst function name
+--- @param block_id integer Unique block identifier for bidirectional linking
+--- @return pandoc.List List of RawBlock elements
+local function ordered_list_to_typst_blocks(ol, wrapper_prefix, block_id)
+  local blocks = {}
+  local start = ol.listAttributes and ol.listAttributes.start or 1
+  for i, item in ipairs(ol.content) do
+    local annot_num = start + i - 1
+    local content_blocks = pandoc.Blocks(item)
+    local rendered = pandoc.write(pandoc.Pandoc(content_blocks), 'typst')
+    rendered = rendered:gsub('%s+$', '')
+    table.insert(blocks, pandoc.RawBlock('typst', string.format(
+      '#%s-annotation-item(%d, %d)[%s]',
+      wrapper_prefix, block_id, annot_num, rendered
+    )))
+  end
+  return blocks
+end
+
+-- ============================================================================
+-- MODULE EXPORTS
+-- ============================================================================
+
+return {
+  LANG_COMMENT_CHARS = LANG_COMMENT_CHARS,
+  resolve_annotations = resolve_annotations,
+  annotations_to_typst_dict = annotations_to_typst_dict,
+  is_annotation_ordered_list = is_annotation_ordered_list,
+  ordered_list_to_typst_blocks = ordered_list_to_typst_blocks,
+}

--- a/_extensions/mcanouil/code-window/_modules/hotfix/skylighting-typst-fix.lua
+++ b/_extensions/mcanouil/code-window/_modules/hotfix/skylighting-typst-fix.lua
@@ -1,0 +1,293 @@
+--- @module skylighting-typst-fix
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @brief Typst skylighting styling override and inline code background.
+--- Pandoc 3.8+ generates correct token colours and bgcolor from the theme,
+--- but the generated Skylighting block lacks styling properties (width, inset,
+--- radius, stroke) and ignores its own fill parameter. This module overrides
+--- the Skylighting function with better block styling and adds inline code
+--- background support for Typst output.
+
+local _wrapper_prefix = 'code-window'
+
+--- Set the wrapper prefix for Typst function name generation.
+--- Called by main.lua before each handler invocation.
+--- @param prefix string The wrapper prefix (e.g. 'code-window' or 'my-window')
+local function set_wrapper(prefix)
+  _wrapper_prefix = prefix
+end
+
+--- Build a Skylighting override with improved block styling.
+--- Pandoc 3.8+ generates correct bgcolor but the block call lacks width,
+--- inset, radius, and stroke properties. The fill parameter is also ignored.
+--- This override fixes both issues.
+--- @return string|nil Typst #let Skylighting(...) definition, or nil
+local function build_skylighting_override()
+  local hm = PANDOC_WRITER_OPTIONS and PANDOC_WRITER_OPTIONS.highlight_method
+  if not hm then return nil end
+
+  local bg = hm['background-color']
+  if not bg or type(bg) ~= 'string' then return nil end
+
+  local circled = _wrapper_prefix .. '-circled-number'
+  return string.format([==[
+// skylighting-typst-fix override
+#let Skylighting(
+  fill: none,
+  number: false,
+  start: 1,
+  sourcelines,
+) = {
+  let bgcolor = if fill != none { fill } else { rgb("%s") }
+  let has-gutter = start + sourcelines.len() > 999
+
+  context {
+    let _page-bg = _cw-page-bg()
+    let _fg = _cw-fg(_page-bg)
+    let _border-colour = color.mix((_fg, 15%%), (_page-bg, 85%%))
+    let annot-data = _cw-annotations.get()
+    let blocks = []
+    let lnum = start - 1
+    let seen-annotes = (:)
+
+    for ln in sourcelines {
+      lnum = lnum + 1
+      if number {
+        blocks = blocks + box(
+          width: if has-gutter { 30pt } else { 24pt },
+          text([ #lnum ]),
+        )
+      }
+
+      if annot-data != none {
+        let annot-num = annot-data.annotations.at(str(lnum), default: none)
+        if annot-num != none {
+          let lbl-prefix = "cw-" + str(annot-data.block-id) + "-"
+          if str(annot-num) not in seen-annotes {
+            seen-annotes.insert(str(annot-num), true)
+            blocks = blocks + box(width: 100%%)[
+              #ln
+              #h(1fr)
+              #link(label(lbl-prefix + "item-" + str(annot-num)))[
+                #%s(annot-num, bg-colour: annot-data.bg-colour)
+              ]
+              #label(lbl-prefix + "line-" + str(annot-num))
+            ]
+          } else {
+            blocks = blocks + box(width: 100%%)[
+              #ln
+              #h(1fr)
+              #link(label(lbl-prefix + "item-" + str(annot-num)))[
+                #%s(annot-num, bg-colour: annot-data.bg-colour)
+              ]
+            ]
+          }
+        } else {
+          blocks = blocks + ln
+        }
+      } else {
+        blocks = blocks + ln
+      }
+      blocks = blocks + EndLine()
+    }
+
+    block(
+      fill: bgcolor,
+      width: 100%%,
+      inset: 8pt,
+      radius: 2pt,
+      stroke: 0.5pt + _border-colour,
+      blocks,
+    )
+  }
+}
+]==], bg, circled, circled)
+end
+
+--- Build a show raw.line rule for annotation support in idiomatic mode.
+--- When Skylighting is not available (idiomatic/native Typst highlighting),
+--- this rule reads _cw-annotations state and adds circled annotation markers
+--- to annotated lines, mirroring what the Skylighting override does.
+--- @return string Typst show rule definition
+local function build_raw_line_annotation_rule()
+  local circled = _wrapper_prefix .. '-circled-number'
+  return string.format([==[
+// idiomatic-mode annotation support for raw blocks
+#show raw.line: it => {
+  context {
+    let annot-data = _cw-annotations.get()
+    if annot-data == none {
+      it
+    } else {
+      let annot-num = annot-data.annotations.at(str(it.number), default: none)
+      if annot-num == none {
+        it
+      } else {
+        let lbl-prefix = "cw-" + str(annot-data.block-id) + "-"
+        let first-line = calc.min(
+          ..annot-data.annotations.pairs()
+            .filter(p => p.at(1) == annot-num)
+            .map(p => int(p.at(0)))
+        )
+        if it.number == first-line {
+          box(width: 100%%)[
+            #it
+            #h(1fr)
+            #link(label(lbl-prefix + "item-" + str(annot-num)))[
+              #%s(annot-num, bg-colour: annot-data.bg-colour)
+            ]
+            #label(lbl-prefix + "line-" + str(annot-num))
+          ]
+        } else {
+          box(width: 100%%)[
+            #it
+            #h(1fr)
+            #link(label(lbl-prefix + "item-" + str(annot-num)))[
+              #%s(annot-num, bg-colour: annot-data.bg-colour)
+            ]
+          ]
+        }
+      }
+    }
+  }
+}
+]==], circled, circled)
+end
+
+--- Process inline Code for Typst format.
+--- Renders the Code element through Pandoc's Typst writer to get syntax-
+--- highlighted output, then wraps it in a box with the theme background colour.
+--- @param el pandoc.Code Inline code element
+--- @return pandoc.RawInline|pandoc.Code Transformed or original element
+local function process_typst_inline(el)
+  local hm = PANDOC_WRITER_OPTIONS and PANDOC_WRITER_OPTIONS.highlight_method
+  local bg_fill = nil
+  local write_opts = nil
+
+  if hm then
+    local bg = hm['background-color']
+    if bg and type(bg) == 'string' then
+      bg_fill = string.format('rgb("%s")', bg)
+    end
+    write_opts = pandoc.WriterOptions({
+      highlight_method = hm,
+    })
+  end
+
+  local rendered = pandoc.write(pandoc.Pandoc({ pandoc.Plain({ el }) }), 'typst', write_opts)
+  rendered = rendered:gsub('%s+$', '')
+  if rendered == '' then return el end
+
+  local typst_code
+  if bg_fill then
+    typst_code = string.format(
+      '#box(fill: %s, inset: (x: 3pt, y: 0pt), outset: (y: 3pt), radius: 2pt, stroke: none)[%s]',
+      bg_fill, rendered)
+  else
+    typst_code = string.format(
+      '#context { let _bg = _cw-page-bg(); let _f = _cw-fg(_bg); '
+      .. 'box(fill: color.mix((_f, 10%%), (_bg, 90%%)), '
+      .. 'inset: (x: 3pt, y: 0pt), outset: (y: 3pt), radius: 2pt, stroke: none)[%s] }',
+      rendered)
+  end
+
+  return pandoc.RawInline('typst', typst_code)
+end
+
+--- Inject Skylighting override at the start of the document.
+--- Always injected when code-window is enabled to support annotation markers.
+function Pandoc(doc)
+  if not quarto.doc.is_format('typst') then
+    return doc
+  end
+
+  -- Guard: skip if override or annotation rule already injected.
+  for _, blk in ipairs(doc.blocks) do
+    if blk.t == 'RawBlock' and blk.format == 'typst'
+        and (blk.text:find('// skylighting-typst-fix override', 1, true)
+          or blk.text:find('// idiomatic-mode annotation support', 1, true)) then
+      return doc
+    end
+  end
+
+  local override = build_skylighting_override()
+  local rule = override or build_raw_line_annotation_rule()
+
+  -- Insert after the code-window function definitions so the override/rule can
+  -- reference _cw-annotations and the wrapper-prefixed circled-number function.
+  local insert_pos = 1
+  for idx, blk in ipairs(doc.blocks) do
+    if blk.t == 'RawBlock' and blk.format == 'typst'
+        and blk.text:find('_cw%-annotations') then
+      insert_pos = idx + 1
+      break
+    end
+  end
+  table.insert(doc.blocks, insert_pos, pandoc.RawBlock('typst', rule))
+  return doc
+end
+
+--- Check if a Div is a Quarto title scaffold (inline-only content).
+--- NOTE: relies on Quarto's internal `__quarto_custom_scaffold` attribute,
+--- which is not part of the public API and may change without notice.
+--- @param div pandoc.Div
+--- @return boolean
+local function is_title_scaffold(div)
+  if div.attributes['__quarto_custom_scaffold'] ~= 'true' then
+    return false
+  end
+  for _, child in ipairs(div.content) do
+    if child.t ~= 'Plain' and child.t ~= 'Para' then
+      return false
+    end
+  end
+  return true
+end
+
+--- Walk the document tree and convert inline Code to RawInline with
+--- background styling. Code in title scaffolds is converted to plain
+--- Typst backtick code to avoid Skylighting tokens with inner quotes
+--- that would break the string parameter Quarto generates.
+--- The typst-title-fix post-quarto filter then evaluates the string
+--- as markup so the backtick code renders with proper inline styling.
+local function process_inline_code(doc)
+  if not quarto.doc.is_format('typst') then
+    return doc
+  end
+
+  local code_filter = { Code = function(el) return process_typst_inline(el) end }
+  local title_filter = {
+    Code = function(el)
+      return pandoc.RawInline('typst', '`' .. el.text .. '`')
+    end,
+  }
+
+  local function walk_blocks(blocks)
+    local new_blocks = {}
+    for _, blk in ipairs(blocks) do
+      if blk.t == 'Div' then
+        if is_title_scaffold(blk) then
+          table.insert(new_blocks, blk:walk(title_filter))
+        else
+          blk.content = walk_blocks(blk.content)
+          table.insert(new_blocks, blk)
+        end
+      else
+        table.insert(new_blocks, blk:walk(code_filter))
+      end
+    end
+    return pandoc.Blocks(new_blocks)
+  end
+
+  doc.blocks = walk_blocks(doc.blocks)
+  return doc
+end
+
+return {
+  set_wrapper = set_wrapper,
+  filters = {
+    { Pandoc = Pandoc },
+    { Pandoc = process_inline_code },
+  },
+}

--- a/_extensions/mcanouil/code-window/_modules/hotfix/typst-title-fix.lua
+++ b/_extensions/mcanouil/code-window/_modules/hotfix/typst-title-fix.lua
@@ -1,0 +1,111 @@
+--- @module typst-title-fix
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @brief Hot-fix for Quarto rendering theorem titles as string parameters.
+--- Quarto renders custom type titles as title: "..." (string mode) which
+--- stringifies any Typst markup. This post-quarto filter scans the source
+--- for cross-reference div IDs, then injects Typst wrapper functions that
+--- evaluate string titles as Typst markup via eval(mode: "markup").
+
+--- Mapping from Quarto cross-reference prefix to Typst function name.
+local PREFIX_TO_FUNC = {
+  thm = 'theorem',
+  lem = 'lemma',
+  cor = 'corollary',
+  prp = 'proposition',
+  cnj = 'conjecture',
+  def = 'definition',
+  exm = 'example',
+  exr = 'exercise',
+  sol = 'solution',
+}
+
+--- Typst wrapper template. %s is replaced with the function name.
+local WRAPPER_TEMPLATE = [==[
+#let _cw-orig-%s = %s
+#let %s(title: none, ..args) = {
+  let t = if title != none and type(title) == str {
+    eval(title, mode: "markup")
+  } else {
+    title
+  }
+  _cw-orig-%s(title: t, ..args)
+}]==]
+
+--- Build Typst code that wraps each theorem function to eval string titles.
+--- @param func_names table List of function names to wrap
+--- @return string Typst code
+local function build_wrappers(func_names)
+  local parts = { '// code-window: hot-fix for Quarto rendering theorem titles as strings.' }
+  for _, name in ipairs(func_names) do
+    table.insert(parts, string.format(WRAPPER_TEMPLATE, name, name, name, name))
+  end
+  return table.concat(parts, '\n')
+end
+
+--- Scan source files for cross-reference div IDs and return the
+--- corresponding Typst function names.
+--- NOTE: uses raw-text pattern matching on source files, so it will not
+--- detect divs inside `include` shortcodes or other indirect sources.
+--- @return table List of function names
+local function detect_theorem_types()
+  local func_names = {}
+  local seen = {}
+  for _, input_file in ipairs(PANDOC_STATE.input_files) do
+    local f = io.open(input_file, 'r')
+    if f then
+      local ok, source = pcall(f.read, f, '*a')
+      f:close()
+      if not ok then source = '' end
+      for prefix in source:gmatch('::: *{#(%w+)%-') do
+        if PREFIX_TO_FUNC[prefix] and not seen[prefix] then
+          table.insert(func_names, PREFIX_TO_FUNC[prefix])
+          seen[prefix] = true
+        end
+      end
+    end
+  end
+  return func_names
+end
+
+return {
+  {
+    Pandoc = function(doc)
+      if not quarto.doc.is_format('typst') then
+        return doc
+      end
+
+      -- Check if the hotfix is enabled via metadata set by the pre-quarto filter.
+      local hotfix_meta = doc.meta['_code-window-hotfix']
+      if hotfix_meta then
+        local enabled = hotfix_meta['typst-title']
+        if enabled and pandoc.utils.stringify(enabled) == 'false' then
+          return doc
+        end
+      end
+
+      -- Guard: skip if already injected.
+      for _, blk in ipairs(doc.blocks) do
+        if blk.t == 'RawBlock' and blk.format == 'typst'
+            and blk.text:find('code-window: hot-fix for Quarto rendering theorem titles', 1, true) then
+          return doc
+        end
+      end
+
+      local func_names = detect_theorem_types()
+      if #func_names == 0 then
+        return doc
+      end
+
+      -- Insert at the start of doc.blocks. RawBlocks placed here appear
+      -- after the Typst template preamble (where make-frame defines the
+      -- theorem functions), so the wrappers can reference them.
+      -- This relies on Quarto emitting the template preamble before
+      -- doc.blocks; if that ordering changes the wrappers will break.
+      table.insert(doc.blocks, 1, pandoc.RawBlock('typst', build_wrappers(func_names)))
+
+      return doc
+    end,
+  },
+}

--- a/_extensions/mcanouil/code-window/_modules/html.lua
+++ b/_extensions/mcanouil/code-window/_modules/html.lua
@@ -1,0 +1,103 @@
+--- MC HTML - HTML generation and dependency management for Quarto Lua filters and shortcodes
+--- @module "html"
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @version 1.0.0
+
+local M = {}
+
+--- Load a sibling module from the same directory as this file.
+--- @param filename string The sibling module filename (e.g., 'string.lua')
+--- @return table The loaded module
+local function load_sibling(filename)
+  local source = debug.getinfo(1, 'S').source:sub(2)
+  local dir = source:match('(.*[/\\])') or ''
+  return require((dir .. filename):gsub('%.lua$', ''))
+end
+
+--- Load string module for escape_html and escape_attribute
+local str = load_sibling('string.lua')
+
+-- ============================================================================
+-- HTML RAW GENERATION UTILITIES
+-- ============================================================================
+
+--- Generates a raw HTML header element.
+--- @param level integer The header level (e.g., 2 for <h2>)
+--- @param text string|nil The header text
+--- @param id string The id attribute for the header
+--- @param classes table List of classes for the header
+--- @param attributes table|nil Additional HTML attributes
+--- @return string Raw HTML string for the header
+function M.raw_header(level, text, id, classes, attributes)
+  local attr_str = ''
+  if id and id ~= '' then
+    attr_str = attr_str .. ' id="' .. str.escape_attribute(id) .. '"'
+  end
+  if classes and #classes > 0 then
+    local escaped_classes = {}
+    for i, cls in ipairs(classes) do
+      escaped_classes[i] = str.escape_attribute(cls)
+    end
+    attr_str = attr_str .. ' class="' .. table.concat(escaped_classes, ' ') .. '"'
+  end
+  if attributes then
+    for k, v in pairs(attributes) do
+      attr_str = attr_str .. ' ' .. str.escape_attribute(k) .. '="' .. str.escape_attribute(v) .. '"'
+    end
+  end
+  return string.format('<h%d%s>%s</h%d>', level, attr_str, str.escape_html(text or ''), level)
+end
+
+-- ============================================================================
+-- HTML DEPENDENCY UTILITIES
+-- ============================================================================
+
+--- Managed HTML dependency tracker
+--- Tracks which dependencies have been added to prevent duplication
+--- @type table<string, boolean>
+local dependency_tracker = {}
+
+--- Ensure HTML dependency is added only once per document.
+--- Prevents duplicate dependency injection by tracking dependencies by name.
+--- Returns true if dependency was added, false if already present.
+---
+--- @param config table Dependency configuration with fields: name (required), version, scripts, stylesheets, head
+--- @return boolean True if dependency was added, false if already added
+--- @usage M.ensure_html_dependency({name = 'my-lib', version = '1.0.0', scripts = {'lib.js'}})
+function M.ensure_html_dependency(config)
+  if not config or not config.name then
+    error("HTML dependency configuration must include a 'name' field")
+  end
+
+  --- @type string Unique key for this dependency
+  local dep_key = config.name
+
+  -- Check if already added
+  if dependency_tracker[dep_key] then
+    return false
+  end
+
+  -- Add the dependency
+  quarto.doc.add_html_dependency(config)
+
+  -- Mark as added
+  dependency_tracker[dep_key] = true
+  return true
+end
+
+--- Reset dependency tracker.
+--- Useful for testing or when processing multiple independent documents.
+--- In normal usage, this should not be called as dependencies persist per document.
+---
+--- @return nil
+function M.reset_dependencies()
+  dependency_tracker = {}
+end
+
+-- ============================================================================
+-- MODULE EXPORT
+-- ============================================================================
+
+return M

--- a/_extensions/mcanouil/code-window/_modules/language.lua
+++ b/_extensions/mcanouil/code-window/_modules/language.lua
@@ -1,0 +1,54 @@
+--- @module language
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @brief Normalise code blocks with no or unknown language class.
+
+local M = {}
+
+local known_language_cache = {}
+
+--- Check if a language is recognised by Pandoc's syntax highlighter.
+--- Renders a test CodeBlock to HTML and checks for the sourceCode class.
+--- @param lang string Language identifier
+--- @return boolean
+local function is_known_language(lang)
+  if not lang or lang == '' then
+    return false
+  end
+
+  if known_language_cache[lang] ~= nil then
+    return known_language_cache[lang]
+  end
+
+  local test_block = pandoc.CodeBlock('x', pandoc.Attr('', { lang }))
+  local html = pandoc.write(pandoc.Pandoc({ test_block }), 'html')
+  local is_known = html:find('sourceCode') ~= nil
+  known_language_cache[lang] = is_known
+  return is_known
+end
+
+--- Normalise code blocks with no or unknown language class to "default".
+--- For unknown languages, preserves the original name as an explicit
+--- filename when one is not already set.
+--- @param block pandoc.CodeBlock
+--- @return pandoc.CodeBlock
+function M.CodeBlock(block)
+  if not block.classes or #block.classes == 0 then
+    block.classes:insert('default')
+    block.attributes['code-window-no-auto-filename'] = 'true'
+    return block
+  end
+
+  local lang = block.classes[1]
+  if not is_known_language(lang) then
+    block.classes[1] = 'default'
+    if not block.attributes['filename'] or block.attributes['filename'] == '' then
+      block.attributes['filename'] = lang
+    end
+  end
+
+  return block
+end
+
+return M

--- a/_extensions/mcanouil/code-window/_modules/logging.lua
+++ b/_extensions/mcanouil/code-window/_modules/logging.lua
@@ -1,0 +1,62 @@
+--- MC Logging - Formatted log output for Quarto Lua filters and shortcodes
+--- @module "logging"
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @version 1.0.0
+
+local M = {}
+
+-- ============================================================================
+-- LOGGING UTILITIES
+-- ============================================================================
+
+--- Format and log an error message with extension prefix.
+--- Provides standardised error messages with consistent formatting across extensions.
+--- Format: [extension-name] Message with details.
+---
+--- @param extension_name string The name of the extension (e.g., "external", "lua-env")
+--- @param message string The error message to display
+--- @usage M.log_error("external", "Could not open file 'example.md'.")
+function M.log_error(extension_name, message)
+  quarto.log.error('[' .. extension_name .. '] ' .. message)
+end
+
+--- Format and log a warning message with extension prefix.
+--- Provides standardised warning messages with consistent formatting across extensions.
+--- Format: [extension-name] Message with details.
+---
+--- @param extension_name string The name of the extension (e.g., "external", "lua-env")
+--- @param message string The warning message to display
+--- @usage M.log_warning("lua-env", "No variable name provided.")
+function M.log_warning(extension_name, message)
+  quarto.log.warning('[' .. extension_name .. '] ' .. message)
+end
+
+--- Format and log an output message with extension prefix.
+--- Provides standardised informational messages with consistent formatting across extensions.
+--- Format: [extension-name] Message with details.
+---
+--- @param extension_name string The name of the extension (e.g., "lua-env")
+--- @param message string The informational message to display
+--- @usage M.log_output("lua-env", "Exported metadata to: output.json")
+function M.log_output(extension_name, message)
+  quarto.log.output('[' .. extension_name .. '] ' .. message)
+end
+
+--- Format and log a debug message with extension prefix.
+--- Provides standardised debug messages with consistent formatting across extensions.
+--- Format: [extension-name] Message with details.
+---
+--- @param extension_name string The name of the extension (e.g., "lua-env")
+--- @param message string The debug message to display
+--- @usage M.log_debug("lua-env", "Variable 'x' has value: 42")
+function M.log_debug(extension_name, message)
+  quarto.log.debug('[' .. extension_name .. '] ' .. message)
+end
+
+-- ============================================================================
+-- MODULE EXPORT
+-- ============================================================================
+
+return M

--- a/_extensions/mcanouil/code-window/_modules/metadata.lua
+++ b/_extensions/mcanouil/code-window/_modules/metadata.lua
@@ -1,0 +1,182 @@
+--- MC Metadata - Extension configuration and metadata access for Quarto Lua filters and shortcodes
+--- @module "metadata"
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @version 1.0.0
+
+local M = {}
+
+--- Load a sibling module from the same directory as this file.
+--- @param filename string The sibling module filename (e.g., 'string.lua')
+--- @return table The loaded module
+local function load_sibling(filename)
+  local source = debug.getinfo(1, 'S').source:sub(2)
+  local dir = source:match('(.*[/\\])') or ''
+  return require((dir .. filename):gsub('%.lua$', ''))
+end
+
+--- Load required modules
+local str = load_sibling('string.lua')
+local log = load_sibling('logging.lua')
+
+-- ============================================================================
+-- METADATA UTILITIES
+-- ============================================================================
+
+--- Get configuration from extensions.name namespace.
+--- @param meta table Document metadata
+--- @param extension_name string The extension name (e.g., "github", "iconify")
+--- @return any The value/table or nil
+--- @usage local value = M.get_extension_config(meta, 'section-outline')
+function M.get_extension_config(meta, extension_name)
+  local config_ext = meta.extensions and meta.extensions[extension_name]
+  if not config_ext then return nil end
+  return config_ext
+end
+
+--- Extract metadata value from document meta using nested structure.
+--- Supports the extensions.{extension-name}.{key} pattern.
+--- @param meta table The document metadata table
+--- @param extension_name string The extension name (e.g., "github", "iconify")
+--- @param key string The metadata key to retrieve
+--- @return string|nil The metadata value as a string, or nil if not found
+--- @usage local repo = M.get_metadata_value(meta, "github", "repository-name")
+function M.get_metadata_value(meta, extension_name, key)
+  if meta['extensions'] and meta['extensions'][extension_name] and meta['extensions'][extension_name][key] then
+    return str.stringify(meta['extensions'][extension_name][key])
+  end
+  return nil
+end
+
+--- Check for deprecated top-level configuration and emit warning
+--- @param meta table The document metadata table
+--- @param extension_name string The extension name
+--- @param key string|nil The configuration key being accessed (nil to check entire extension config)
+--- @param deprecation_warning_shown boolean Flag to track if warning has been shown
+--- @return any|nil The value from deprecated config, or nil if not found
+--- @return boolean Updated deprecation warning flag
+function M.check_deprecated_config(meta, extension_name, key, deprecation_warning_shown)
+  -- Handle array-based configuration (when key is nil)
+  if key == nil then
+    if not str.is_empty(meta[extension_name]) then
+      if not deprecation_warning_shown then
+        log.log_warning(
+          extension_name,
+          'Top-level "' .. extension_name .. '" configuration is deprecated. ' ..
+          'Please use:\n' ..
+          'extensions:\n' ..
+          '  ' .. extension_name .. ':\n' ..
+          '    - (configuration array)'
+        )
+        deprecation_warning_shown = true
+      end
+      return meta[extension_name], deprecation_warning_shown
+    end
+    return nil, deprecation_warning_shown
+  end
+
+  -- Handle key-value configuration (original behaviour)
+  if not str.is_empty(meta[extension_name]) and not str.is_empty(meta[extension_name][key]) then
+    if not deprecation_warning_shown then
+      log.log_warning(
+        extension_name,
+        'Top-level "' .. extension_name .. '" configuration is deprecated. ' ..
+        'Please use:\n' ..
+        'extensions:\n' ..
+        '  ' .. extension_name .. ':\n' ..
+        '    ' .. key .. ': value'
+      )
+      deprecation_warning_shown = true
+    end
+    return str.stringify(meta[extension_name][key]), deprecation_warning_shown
+  end
+  return nil, deprecation_warning_shown
+end
+
+-- ============================================================================
+-- ENHANCED METADATA/CONFIGURATION UTILITIES
+-- ============================================================================
+
+--- Get option value with fallback hierarchy: args -> extensions.{extension}.{key} -> defaults.
+--- Provides a standardised way to read configuration values with multiple fallback levels.
+--- Priority: 1. Named arguments (kwargs), 2. Document metadata, 3. Default values.
+---
+--- @param spec table Configuration spec with fields: extension (string), key (string), args (table|nil), meta (table|nil), default (any|nil)
+--- @return any The resolved option value (type depends on what's stored in config)
+--- @usage local duration = M.get_option_with_fallbacks({extension = 'animate', key = 'duration', args = kwargs, meta = meta, default = '3s'})
+function M.get_option_with_fallbacks(spec)
+  -- Validate required fields
+  if not spec.extension or not spec.key then
+    error("Configuration spec must include 'extension' and 'key' fields")
+  end
+
+  --- @type string The extension name
+  local extension = spec.extension
+  --- @type string The configuration key
+  local key = spec.key
+  --- @type table|nil Named arguments table
+  local args = spec.args
+  --- @type table|nil Document metadata
+  local meta = spec.meta
+  --- @type any Default value if not found elsewhere
+  local default = spec.default
+
+  -- Priority 1: Check named arguments (kwargs)
+  if args and args[key] then
+    local arg_value = str.stringify(args[key])
+    if not str.is_empty(arg_value) then
+      return arg_value
+    end
+  end
+
+  -- Priority 2: Check metadata extensions.{extension}.{key}
+  if meta then
+    local meta_value = M.get_metadata_value(meta, extension, key)
+    if not str.is_empty(meta_value) then
+      return meta_value
+    end
+  end
+
+  -- Priority 3: Return default value
+  return default
+end
+
+--- Get multiple option values at once with fallback hierarchy.
+--- Batch version of get_option_with_fallbacks for retrieving multiple configuration values.
+--- Returns a table mapping each key to its resolved value.
+---
+--- @param spec table Configuration spec with fields: extension (string), keys (table<integer, string>), args (table|nil), meta (table|nil), defaults (table<string, any>|nil)
+--- @return table<string, any> Table mapping each key to its resolved value
+--- @usage local opts = M.get_options({extension = 'animate', keys = {'duration', 'delay'}, args = kwargs, meta = meta, defaults = {duration = '3s', delay = '2s'}})
+function M.get_options(spec)
+  -- Validate required fields
+  if not spec.extension or not spec.keys then
+    error("Configuration spec must include 'extension' and 'keys' fields")
+  end
+
+  --- @type table<string, any> Result table
+  local result = {}
+
+  --- @type table Default values table
+  local defaults = spec.defaults or {}
+
+  -- Get each key using the single-option fallback logic
+  for _, key in ipairs(spec.keys) do
+    result[key] = M.get_option_with_fallbacks({
+      extension = spec.extension,
+      key = key,
+      args = spec.args,
+      meta = spec.meta,
+      default = defaults[key]
+    })
+  end
+
+  return result
+end
+
+-- ============================================================================
+-- MODULE EXPORT
+-- ============================================================================
+
+return M

--- a/_extensions/mcanouil/code-window/_modules/pandoc-helpers.lua
+++ b/_extensions/mcanouil/code-window/_modules/pandoc-helpers.lua
@@ -1,0 +1,152 @@
+--- MC Pandoc Helpers - Pandoc element construction and format detection for Quarto Lua filters and shortcodes
+--- @module "pandoc_helpers"
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @version 1.0.0
+
+local M = {}
+
+--- Load a sibling module from the same directory as this file.
+--- @param filename string The sibling module filename (e.g., 'string.lua')
+--- @return table The loaded module
+local function load_sibling(filename)
+  local source = debug.getinfo(1, 'S').source:sub(2)
+  local dir = source:match('(.*[/\\])') or ''
+  return require((dir .. filename):gsub('%.lua$', ''))
+end
+
+--- Load string module for is_empty
+local str = load_sibling('string.lua')
+
+-- ============================================================================
+-- PANDOC/QUARTO FORMAT UTILITIES
+-- ============================================================================
+
+--- Create a Pandoc Link element
+--- @param text string|nil The link text
+--- @param uri string|nil The URI to link to
+--- @return pandoc.Link|nil A Pandoc Link element or nil if text or uri is empty
+function M.create_link(text, uri)
+  if not str.is_empty(uri) and not str.is_empty(text) then
+    return pandoc.Link({ pandoc.Str(text --[[@as string]]) }, uri --[[@as string]])
+  end
+  return nil
+end
+
+--- Helper to build Pandoc attributes
+--- @param id string|nil Element ID
+--- @param classes table|nil List of CSS classes
+--- @param attributes table|nil Key-value attributes
+--- @return pandoc.Attr Pandoc Attr object
+function M.attr(id, classes, attributes)
+  return pandoc.Attr(id or '', classes or {}, attributes or {})
+end
+
+--- Check if a class list contains a specific class name
+--- @param classes table|nil List of CSS classes
+--- @param name string The class name to search for
+--- @return boolean True if the class is found, false otherwise
+function M.has_class(classes, name)
+  if not classes then return false end
+  for _, cls in ipairs(classes) do
+    if cls == name then return true end
+  end
+  return false
+end
+
+--- Add a class to the class list if it doesn't already exist
+--- @param classes table List of CSS classes
+--- @param name string The class name to add
+function M.add_class(classes, name)
+  if not M.has_class(classes, name) then
+    table.insert(classes, name)
+  end
+end
+
+--- Retrieve the current Quarto output format.
+--- @return string The output format ("pptx", "html", "latex", "typst", "docx", or "unknown")
+--- @return string The language of the output format
+function M.get_quarto_format()
+  if quarto.doc.is_format('html:js') then
+    return 'html', 'html'
+  elseif quarto.doc.is_format('latex') then
+    return 'latex', 'latex'
+  elseif quarto.doc.is_format('typst') then
+    return 'typst', 'typst'
+  elseif quarto.doc.is_format('docx') then
+    return 'docx', 'openxml'
+  elseif quarto.doc.is_format('pptx') then
+    return 'pptx', 'openxml'
+  else
+    return 'unknown', 'unknown'
+  end
+end
+
+-- ============================================================================
+-- OBJECT/TABLE UTILITIES
+-- ============================================================================
+
+--- Check if an object (including tables and lists) is empty or nil
+--- @param obj any The object to check
+--- @return boolean true if the object is nil, empty string, or empty table/list
+function M.is_object_empty(obj)
+  local function length(x)
+    local count = 0
+    if x ~= nil then
+      for _ in pairs(x) do
+        count = count + 1
+      end
+    end
+    return count
+  end
+  if pandoc.utils.type(obj) == 'table' or pandoc.utils.type(obj) == 'List' then
+    return obj == nil or obj == '' or length(obj) == 0
+  else
+    return obj == nil or obj == ''
+  end
+end
+
+--- Check if an object is a simple type (string, number, or boolean)
+--- @param obj any The object to check
+--- @return boolean true if the object is a string, number, or boolean
+function M.is_type_simple(obj)
+  return pandoc.utils.type(obj) == 'string' or pandoc.utils.type(obj) == 'number' or pandoc.utils.type(obj) == 'boolean'
+end
+
+--- Check if an object is a function or userdata
+--- @param obj any The object to check
+--- @return boolean true if the object is a function or userdata
+function M.is_function_userdata(obj)
+  return pandoc.utils.type(obj) == 'function' or pandoc.utils.type(obj) == 'userdata'
+end
+
+--- Get nested value from object using field path
+--- @param fields table Array of field names to traverse
+--- @param obj table The object to extract value from
+--- @return any The value at the nested path
+--- @usage local val = M.get_value({"a", "b", "c"}, obj)
+function M.get_value(fields, obj)
+  local value = obj
+  for _, field in ipairs(fields) do
+    value = value[field]
+  end
+  return value
+end
+
+--- Convert Pandoc AttributeList to plain table for easier processing.
+--- @param element table Element with attributes field (Div, Span, Table, Image)
+--- @return table Plain table with attribute key-value pairs
+function M.attributes_to_table(element)
+  local attrs = {}
+  for k, v in pairs(element.attributes) do
+    attrs[k] = v
+  end
+  return attrs
+end
+
+-- ============================================================================
+-- MODULE EXPORT
+-- ============================================================================
+
+return M

--- a/_extensions/mcanouil/code-window/_modules/string.lua
+++ b/_extensions/mcanouil/code-window/_modules/string.lua
@@ -1,0 +1,198 @@
+--- MC String - String manipulation and escaping for Quarto Lua filters and shortcodes
+--- @module "string"
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @version 1.0.0
+
+local M = {}
+
+-- ============================================================================
+-- STRING UTILITIES
+-- ============================================================================
+
+--- Pandoc utility function for converting values to strings
+--- @type function
+M.stringify = pandoc.utils.stringify
+
+--- Check if a string is empty or nil.
+--- Utility function to determine if a value is empty or nil,
+--- which is useful for parameter validation throughout the module.
+--- @param s string|nil|table The value to check for emptiness
+--- @return boolean True if the value is nil or empty, false otherwise
+--- @usage local result = M.is_empty("") -- returns true
+--- @usage local result = M.is_empty(nil) -- returns true
+--- @usage local result = M.is_empty("hello") -- returns false
+function M.is_empty(s)
+  return s == nil or s == ''
+end
+
+--- Escape special pattern characters in a string for Lua pattern matching
+--- @param s string The string to escape
+--- @return string The escaped string
+--- @usage local escaped = M.escape_pattern("user/repo#123")
+function M.escape_pattern(s)
+  local escaped = s:gsub('([%^%$%(%)%%%.%[%]%*%+%-%?])', '%%%1')
+  return escaped
+end
+
+--- Split a string by a separator
+--- @param str string The string to split
+--- @param sep string The separator pattern
+--- @return table Array of string fields
+--- @usage local parts = M.split("a.b.c", ".")
+function M.split(str, sep)
+  local fields = {}
+  local pattern = string.format('([^%s]+)', sep)
+  str:gsub(pattern, function(c) fields[#fields + 1] = c end)
+  return fields
+end
+
+--- Trim leading and trailing whitespace from a string
+--- @param str string The string to trim
+--- @return string The trimmed string
+--- @usage local trimmed = M.trim("  hello world  ") -- returns "hello world"
+function M.trim(str)
+  if str == nil then return '' end
+  return str:match('^%s*(.-)%s*$')
+end
+
+--- Convert any value to a string, handling Pandoc objects and empty values.
+--- Returns nil for empty or nil values, otherwise returns a string representation.
+--- @param val any The value to convert
+--- @return string|nil The string value or nil if empty
+--- @usage local str = M.to_string(kwargs.value)
+function M.to_string(val)
+  if not val then return nil end
+  if type(val) == 'string' then
+    return val ~= '' and val or nil
+  end
+  -- Handle Pandoc objects
+  if pandoc and pandoc.utils and pandoc.utils.stringify then
+    local str = pandoc.utils.stringify(val)
+    return str ~= '' and str or nil
+  end
+  local str = tostring(val)
+  return str ~= '' and str or nil
+end
+
+-- ============================================================================
+-- ESCAPE UTILITIES
+-- ============================================================================
+
+--- Escape special LaTeX characters in text.
+--- @param text string The text to escape
+--- @return string The escaped text safe for LaTeX
+function M.escape_latex(text)
+  text = string.gsub(text, '\\', '\\textbackslash{}')
+  text = string.gsub(text, '%{', '\\{')
+  text = string.gsub(text, '%}', '\\}')
+  text = string.gsub(text, '%$', '\\$')
+  text = string.gsub(text, '%&', '\\&')
+  text = string.gsub(text, '%%', '\\%%')
+  text = string.gsub(text, '%#', '\\#')
+  text = string.gsub(text, '%^', '\\textasciicircum{}')
+  text = string.gsub(text, '%_', '\\_')
+  text = string.gsub(text, '~', '\\textasciitilde{}')
+  return text
+end
+
+--- Escape special Typst characters in text.
+--- @param text string The text to escape
+--- @return string The escaped text safe for Typst
+function M.escape_typst(text)
+  text = string.gsub(text, '%#', '\\#')
+  return text
+end
+
+--- Escape characters for Typst string literals (inside `"..."`).
+--- @param text string The text to escape
+--- @return string The escaped text safe for Typst string literals
+function M.escape_typst_string(text)
+  return text:gsub('\\', '\\\\'):gsub('"', '\\"')
+end
+
+--- Escape special Lua pattern characters for use in string.gsub.
+--- @param text string The text containing characters to escape
+--- @return string The escaped text safe for Lua patterns
+function M.escape_lua_pattern(text)
+  text = string.gsub(text, '%%', '%%%%')
+  text = string.gsub(text, '%^', '%%^')
+  text = string.gsub(text, '%$', '%%$')
+  text = string.gsub(text, '%(', '%%(')
+  text = string.gsub(text, '%)', '%%)')
+  text = string.gsub(text, '%.', '%%.')
+  text = string.gsub(text, '%[', '%%[')
+  text = string.gsub(text, '%]', '%%]')
+  text = string.gsub(text, '%*', '%%*')
+  text = string.gsub(text, '%+', '%%+')
+  text = string.gsub(text, '%-', '%%-')
+  text = string.gsub(text, '%?', '%%?')
+  return text
+end
+
+--- Escape special HTML characters in text.
+--- Escapes &, <, >, ", and ' to prevent XSS and ensure valid HTML.
+--- @param text string The text to escape
+--- @return string Escaped text safe for use in HTML
+--- @usage local escaped = M.escape_html('Hello <World>')
+function M.escape_html(text)
+  if text == nil then return '' end
+  if type(text) ~= 'string' then text = tostring(text) end
+  local result = text
+      :gsub('&', '&amp;')
+      :gsub('<', '&lt;')
+      :gsub('>', '&gt;')
+      :gsub('"', '&quot;')
+      :gsub("'", '&#39;')
+  return result
+end
+
+--- Escape special HTML attribute characters.
+--- Escapes characters that could break attribute values.
+--- @param value string The attribute value to escape
+--- @return string Escaped value safe for use in HTML attributes
+--- @usage local escaped = M.escape_attribute('Hello "World"')
+function M.escape_attribute(value)
+  if value == nil then return '' end
+  if type(value) ~= 'string' then value = tostring(value) end
+  local result = value
+      :gsub('&', '&amp;')
+      :gsub('"', '&quot;')
+      :gsub('<', '&lt;')
+      :gsub('>', '&gt;')
+  return result
+end
+
+--- Escape text for different formats.
+--- @param text string The text to escape
+--- @param format string The format to escape for (e.g., "latex", "typst", "lua")
+--- @return string The escaped text
+function M.escape_text(text, format)
+  local escape_functions = {
+    latex = M.escape_latex,
+    typst = M.escape_typst,
+    lua = M.escape_lua_pattern
+  }
+
+  local escape = escape_functions[format]
+  if escape then
+    return escape(text)
+  else
+    error('Unsupported escape format: ' .. format)
+  end
+end
+
+--- Converts a string to a valid HTML id by lowercasing and replacing spaces.
+--- @param text string The text to convert
+--- @return string The HTML id
+function M.ascii_id(text)
+  local id = text:lower():gsub('[^a-z0-9 ]', ''):gsub(' +', '-')
+  return id
+end
+
+-- ============================================================================
+-- MODULE EXPORT
+-- ============================================================================
+
+return M

--- a/_extensions/mcanouil/code-window/_schema.yml
+++ b/_extensions/mcanouil/code-window/_schema.yml
@@ -1,0 +1,88 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+options:
+  enabled:
+    type: boolean
+    default: true
+    description: "Enable or disable the code-window filter."
+  auto-filename:
+    type: boolean
+    default: true
+    description: "Automatically generate filename labels from the code block language."
+  style:
+    type: string
+    enum: ["default", "macos", "windows"]
+    default: "macos"
+    description: "Window decoration style: 'macos' (traffic lights), 'windows' (title bar buttons), or 'default' (plain filename). Can be overridden per block with the 'code-window-style' attribute."
+  wrapper:
+    type: string
+    default: "code-window"
+    description: "Typst wrapper function name for code-window rendering."
+  collapse:
+    type: [boolean, string]
+    enum: [true, false, "open", "closed"]
+    default: false
+    description: "Wrap every code-window block in a collapsible <details> element (HTML only). Use 'open' to render expanded by default, 'closed' or true to render collapsed by default, false to disable. Per-block overrides use the 'code-window-collapse' attribute."
+  lines-label:
+    type: boolean
+    default: true
+    description: "Render a small chip next to the filename showing the highlighted-line spec for blocks that set 'code-line-numbers' or 'code-window-lines'."
+  hotfix:
+    type: object
+    description: "Temporary hot-fixes for Typst output. These will be removed when Quarto natively supports the corresponding features (see quarto-dev/quarto-cli#14170)."
+    properties:
+      code-annotations:
+        type: [boolean, object]
+        default: true
+        description: "Enable the code-annotations hot-fix for Typst output. Use a boolean or a map with 'enabled' and 'quarto-version' keys."
+        properties:
+          enabled:
+            type: boolean
+            description: "Explicitly enable or disable this hot-fix."
+          quarto-version:
+            type: string
+            description: "Quarto version at or above which this hot-fix is automatically disabled."
+      skylighting:
+        type: [boolean, object]
+        default: true
+        description: "Enable the Skylighting hot-fix for Typst output (overrides block styling and adds inline code background). Use a boolean or a map with 'enabled' and 'quarto-version' keys."
+        properties:
+          enabled:
+            type: boolean
+            description: "Explicitly enable or disable this hot-fix."
+          quarto-version:
+            type: string
+            description: "Quarto version at or above which this hot-fix is automatically disabled."
+      typst-title:
+        type: [boolean, object]
+        default: true
+        description: "Enable the Typst title hot-fix (evaluates theorem title strings as markup). Use a boolean or a map with 'enabled' and 'quarto-version' keys."
+        properties:
+          enabled:
+            type: boolean
+            description: "Explicitly enable or disable this hot-fix."
+          quarto-version:
+            type: string
+            description: "Quarto version at or above which this hot-fix is automatically disabled."
+
+attributes:
+  CodeBlock:
+    code-window-enabled:
+      type: boolean
+      default: true
+      description: "Whether to apply window chrome to this specific code block. Set to false to disable. Annotations still render when disabled."
+    code-window-no-auto-filename:
+      type: boolean
+      default: false
+      description: "Suppress the auto-generated filename for this specific code block without changing the global setting."
+    code-window-style:
+      type: string
+      enum: ["default", "macos", "windows"]
+      description: "Override the global window decoration style for this specific code block."
+    code-window-collapse:
+      type: [boolean, string]
+      enum: [true, false, "open", "closed"]
+      description: "Wrap this code block in a collapsible <details> element (HTML only). Use 'open' to render expanded, 'closed' or true to render collapsed, false to disable."
+    code-window-lines:
+      type: string
+      description: "Highlighted-lines spec rendered as a chip alongside the filename (e.g. '1,3-5'). When omitted, Quarto's 'code-line-numbers' attribute is used."

--- a/_extensions/mcanouil/code-window/code-window.lua
+++ b/_extensions/mcanouil/code-window/code-window.lua
@@ -1,0 +1,1117 @@
+--- @module code-window
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @brief Code block window decorations with multiple styles
+--- @description Adds window chrome (macOS traffic lights, Windows title bar
+--- buttons, or plain filename) to code blocks in HTML, Reveal.js, and Typst
+--- formats. Registered at pre-quarto to process all formats in a single pass.
+
+-- ============================================================================
+-- EXTENSION NAME
+-- ============================================================================
+
+local EXTENSION_NAME = 'code-window'
+local str = require(quarto.utils.resolve_path('_modules/string.lua'):gsub('%.lua$', ''))
+local log = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lua$', ''))
+local meta_mod = require(quarto.utils.resolve_path('_modules/metadata.lua'):gsub('%.lua$', ''))
+local pdoc = require(quarto.utils.resolve_path('_modules/pandoc-helpers.lua'):gsub('%.lua$', ''))
+local html_mod = require(quarto.utils.resolve_path('_modules/html.lua'):gsub('%.lua$', ''))
+local code_annotations = nil
+
+-- ============================================================================
+-- DEFAULTS AND STATE
+-- ============================================================================
+
+--- @class CodeWindowConfig
+--- @field enabled boolean Whether code-window styling is enabled
+--- @field auto_filename boolean Whether to auto-generate filename from language
+--- @field style string Window decoration style ('macos', 'windows', 'default')
+--- @field typst_wrapper string Typst wrapper function name
+--- @field hotfix_code_annotations boolean Whether to apply the code-annotations hot-fix for Typst
+--- @field hotfix_skylighting boolean Whether to apply the Skylighting hot-fix for Typst
+
+local VALID_STYLES = { ['default'] = true, ['macos'] = true, ['windows'] = true }
+
+local DEFAULTS = {
+  ['enabled'] = 'true',
+  ['auto-filename'] = 'true',
+  ['style'] = 'macos',
+  ['wrapper'] = 'code-window',
+  ['collapse'] = 'false',
+  ['lines-label'] = 'true',
+}
+
+local VALID_COLLAPSE = {
+  ['false'] = false,
+  ['true'] = 'closed',
+  ['closed'] = 'closed',
+  ['open'] = 'open',
+}
+
+local HOTFIX_DEFAULTS = {
+  ['code-annotations'] = true,
+  ['skylighting'] = true,
+  ['typst-title'] = true,
+}
+
+local CURRENT_FORMAT = nil
+local CONFIG = nil
+local TYPST_BG_COLOUR = nil
+local ANNOTATION_BLOCK_COUNTER = 0
+
+-- ============================================================================
+-- BLOCK-LEVEL STYLE OVERRIDE
+-- ============================================================================
+
+--- Read the block-level style override from code-window-style attribute.
+--- Returns the validated style value or nil.
+--- Strips the attribute from the block.
+--- @param block pandoc.CodeBlock Code block element
+--- @return string|nil Style override value
+local function read_block_style(block)
+  local block_style = block.attributes['code-window-style']
+  if not block_style or block_style == '' then
+    return nil
+  end
+  block.attributes['code-window-style'] = nil
+  if VALID_STYLES[block_style] then
+    return block_style
+  end
+  log.log_warning(EXTENSION_NAME,
+    string.format('Unknown block style "%s", using configured default.', block_style))
+  return nil
+end
+
+--- Resolve a collapse value coming from extension options or a code-block
+--- attribute. Returns "open"/"closed" when the window should be collapsible,
+--- nil when collapsing is off or the value is unrecognised.
+--- Emits a warning when the input is set but not understood.
+--- @param raw string|nil Raw collapse value
+--- @return string|nil Resolved collapse mode ("open"/"closed") or nil
+local function resolve_collapse(raw)
+  if raw == nil or raw == '' then
+    return nil
+  end
+  local resolved = VALID_COLLAPSE[raw]
+  if resolved == nil then
+    log.log_warning(EXTENSION_NAME,
+      string.format('Unknown collapse value "%s", expected one of true/false/open/closed.', raw))
+    return nil
+  end
+  if resolved == false then
+    return nil
+  end
+  return resolved
+end
+
+--- Read the per-block collapse override from code-window-collapse attribute.
+--- Always strips the attribute from the block before resolving.
+--- @param block pandoc.CodeBlock Code block element
+--- @return string|nil Resolved collapse mode ("open"/"closed") or nil when off
+local function read_block_collapse(block)
+  local raw = block.attributes['code-window-collapse']
+  if raw == nil then
+    return nil
+  end
+  block.attributes['code-window-collapse'] = nil
+  return resolve_collapse(raw)
+end
+
+--- Read a highlight-lines spec from the block, looking at the
+--- code-window-lines attribute first and falling back to Quarto's
+--- code-line-numbers attribute when it carries a non-boolean spec.
+--- Returns the cleaned spec string or nil.
+--- @param block pandoc.CodeBlock Code block element
+--- @return string|nil Line spec to display in the title bar
+local function read_block_lines_label(block)
+  local raw = block.attributes['code-window-lines']
+  if raw ~= nil then
+    block.attributes['code-window-lines'] = nil
+    if raw ~= '' then
+      return raw
+    end
+  end
+
+  local cln = block.attributes['code-line-numbers']
+  if not cln or cln == '' or cln == 'true' or cln == 'false' then
+    return nil
+  end
+  return cln
+end
+
+-- ============================================================================
+-- TYPST FUNCTION DEFINITION
+-- ============================================================================
+
+--- Typst colour helpers for adaptive theme support.
+--- Always injected so the code-window function can derive border, surface,
+--- and muted colours from the page background at render time.
+local TYPST_COLOUR_HELPERS = [==[
+// code-window: adaptive colour helpers (derive UI tones from page background)
+#let _cw-page-bg() = {
+  let f = page.fill
+  if type(f) == color { f } else { luma(255) }
+}
+
+#let _cw-fg(bg) = {
+  let comps = bg.components(alpha: false)
+  let lum = if comps.len() == 1 {
+    comps.at(0) / 100%
+  } else {
+    0.2126 * comps.at(0) / 100% + 0.7152 * comps.at(1) / 100% + 0.0722 * comps.at(2) / 100%
+  }
+  if lum < 0.5 { luma(255) } else { luma(0) }
+}
+]==]
+
+--- Typst annotation helper functions (state, colour, circled numbers, annotation items).
+--- Only injected when at least one hot-fix is active.
+local TYPST_ANNOTATION_DEF = [==[
+// code-window: annotation state passed to Skylighting via Typst state
+#let _cw-annotations = state("cw-annotations", none)
+
+// Derive a contrasting annotation colour from a background fill.
+// Light backgrounds get dark circles; dark backgrounds get light circles.
+// Uses ITU-R BT.709 luminance coefficients, matching quarto-cli PR #14170.
+#let code-window-annote-colour(bg) = {
+  if type(bg) == color {
+    let comps = bg.components(alpha: false)
+    let lum = if comps.len() == 1 {
+      comps.at(0) / 100%
+    } else {
+      0.2126 * comps.at(0) / 100% + 0.7152 * comps.at(1) / 100% + 0.0722 * comps.at(2) / 100%
+    }
+    if lum < 0.5 { luma(200) } else { luma(60) }
+  } else {
+    luma(60)
+  }
+}
+
+#let code-window-circled-number(n, bg-colour: none) = {
+  let c = if bg-colour != none { code-window-annote-colour(bg-colour) } else { luma(120) }
+  box(baseline: 20%, circle(
+    radius: 4.5pt,
+    stroke: 0.5pt + c,
+  )[#set text(size: 5.5pt, fill: c); #align(center + horizon, str(n))])
+}
+
+#let code-window-annotation-item(block-id, n, content) = {
+  let lbl-prefix = "cw-" + str(block-id) + "-"
+  context {
+    let target = label(lbl-prefix + "line-" + str(n))
+    let has-target = query(target).len() > 0
+    [#block(above: 0.4em, below: 0.4em)[
+      #if has-target {
+        link(target)[#code-window-circled-number(n)]
+      } else {
+        code-window-circled-number(n)
+      }
+      #h(0.4em)
+      #content
+    ] #label(lbl-prefix + "item-" + str(n))]
+  }
+}
+
+#let code-window-annotated-content(content, annotations: (:), bg-colour: none, block-id: 0) = {
+  if annotations.len() > 0 {
+    _cw-annotations.update((annotations: annotations, bg-colour: bg-colour, block-id: block-id))
+    content
+    _cw-annotations.update(none)
+  } else {
+    content
+  }
+}
+]==]
+
+--- Typst code-window body content template.
+--- Uses annotation wrapper when hot-fixes are active, plain content otherwise.
+local TYPST_CONTENT_WITH_ANNOTATIONS = [==[
+        code-window-annotated-content(
+          content,
+          annotations: annotations,
+          bg-colour: bg-colour,
+          block-id: block-id,
+        )
+]==]
+
+local TYPST_CONTENT_PLAIN = [==[
+        content
+]==]
+
+--- Build the complete Typst code-window function definition.
+--- @param has_hotfixes boolean Whether at least one hot-fix is active
+--- @return string Typst function definition(s)
+local function build_typst_function_def(has_hotfixes)
+  local content_block = has_hotfixes
+      and TYPST_CONTENT_WITH_ANNOTATIONS
+      or TYPST_CONTENT_PLAIN
+
+  local fn_def = string.format([==[
+#let code-window(
+  content,
+  filename: none,
+  is-auto: false,
+  style: "macos",
+  annotations: (:),
+  bg-colour: none,
+  block-id: 0,
+  lines-label: none,
+) = {
+  context {
+  let page-bg = _cw-page-bg()
+  let fg = _cw-fg(page-bg)
+  let border-colour = color.mix((fg, 15%%), (page-bg, 85%%))
+  let surface-fill = color.mix((fg, 5%%), (page-bg, 95%%))
+  let muted-colour = color.mix((fg, 50%%), (page-bg, 50%%))
+
+  let filename-label = if filename != none {
+    text(
+      size: if is-auto { 0.7em } else { 0.85em },
+      weight: 500,
+      fill: muted-colour,
+      if is-auto { upper(filename) } else { filename },
+    )
+  }
+
+  let lines-chip = if lines-label != none {
+    box(
+      inset: (x: 0.4em, y: 0.05em),
+      outset: (y: 0.15em),
+      radius: 3pt,
+      fill: color.mix((fg, 10%%), (page-bg, 90%%)),
+      stroke: 0.5pt + border-colour,
+      text(size: 0.7em, weight: 500, fill: muted-colour, lines-label),
+    )
+  }
+
+  let traffic-lights = box(
+    inset: (right: 0.5em),
+    stack(
+      dir: ltr,
+      spacing: 0.425em,
+      circle(radius: 0.425em, fill: rgb("#ff5f56"), stroke: none),
+      circle(radius: 0.425em, fill: rgb("#ffbd2e"), stroke: none),
+      circle(radius: 0.425em, fill: rgb("#27c93f"), stroke: none),
+    ),
+  )
+
+  let window-buttons = box(
+    inset: (left: 0.5em),
+    {
+      set line(stroke: 1pt + muted-colour)
+      stack(
+        dir: ltr,
+        spacing: 0.8em,
+        // Minimise (horizontal line)
+        box(width: 0.6em, height: 0.6em, align(horizon, line(length: 100%%))),
+        // Maximise (square)
+        box(width: 0.6em, height: 0.6em, stroke: 1pt + muted-colour),
+        // Close (x)
+        box(width: 0.6em, height: 0.6em, {
+          place(line(start: (0%%, 0%%), end: (100%%, 100%%)))
+          place(line(start: (100%%, 0%%), end: (0%%, 100%%)))
+        }),
+      )
+    },
+  )
+
+  let _label-with-chip = if lines-chip != none {
+    stack(dir: ltr, spacing: 0.5em, filename-label, lines-chip)
+  } else {
+    filename-label
+  }
+
+  let title-bar = if style == "macos" {
+    grid(
+      columns: (auto, 1fr),
+      align: (left + horizon, right + horizon),
+      gutter: 0.5em,
+      stroke: 0pt,
+      traffic-lights,
+      _label-with-chip,
+    )
+  } else if style == "windows" {
+    grid(
+      columns: (1fr, auto),
+      align: (left + horizon, right + horizon),
+      gutter: 0.5em,
+      stroke: 0pt,
+      _label-with-chip,
+      window-buttons,
+    )
+  } else {
+    // default: plain filename, left-aligned
+    _label-with-chip
+  }
+
+  block(
+    width: 100%%,
+    stroke: 1pt + border-colour,
+    radius: 8pt,
+    clip: true,
+    {
+      block(
+        width: 100%%,
+        fill: surface-fill,
+        inset: (x: 1em, y: 0.6em),
+        below: 0pt,
+        radius: 0pt,
+        stroke: (bottom: 1pt + border-colour),
+        title-bar,
+      )
+      // Strip code block chrome so content fills flush against the window body.
+      // set block() provides defaults for Skylighting blocks (explicit fill preserved).
+      // show raw overrides the document-level raw block styling (fill, radius).
+      {
+        set block(
+          width: 100%%,
+          inset: 8pt,
+          radius: 0pt,
+          stroke: none,
+          above: 0pt,
+          below: 0pt,
+        )
+        show raw.where(block: true): set block(
+          fill: none,
+          width: 100%%,
+          radius: 0pt,
+          stroke: none,
+          above: 0pt,
+          below: 0pt,
+        )
+%s      }
+    },
+  )
+  }
+}
+]==], content_block)
+
+  local result = TYPST_COLOUR_HELPERS
+  if has_hotfixes then
+    result = result .. TYPST_ANNOTATION_DEF
+  end
+  return result .. fn_def
+end
+
+-- ============================================================================
+-- TYPST PROCESSING
+-- ============================================================================
+
+--- Get the next unique block ID for annotation linking.
+--- @return integer
+local function next_block_id()
+  ANNOTATION_BLOCK_COUNTER = ANNOTATION_BLOCK_COUNTER + 1
+  return ANNOTATION_BLOCK_COUNTER
+end
+
+--- Build the Typst bg-colour parameter string.
+--- @return string Empty string or ', bg-colour: rgb("...")'
+local function typst_bg_colour_param()
+  if not TYPST_BG_COLOUR then
+    return ''
+  end
+  return string.format(', bg-colour: rgb("%s")', TYPST_BG_COLOUR)
+end
+
+--- Escape a string for embedding in a Typst double-quoted string literal.
+--- @param s string
+--- @return string
+local function typst_escape_string(s)
+  return (s:gsub('\\', '\\\\'):gsub('"', '\\"'))
+end
+
+--- Build a code-window opening RawBlock for Typst.
+--- @param filename string
+--- @param is_auto boolean
+--- @param style string
+--- @param annotations table|nil
+--- @param block_id integer
+--- @param lines_label string|nil Highlighted-lines spec to display in the title bar
+--- @return pandoc.RawBlock
+local function typst_code_window_open(filename, is_auto, style, annotations, block_id, lines_label)
+  local annot_param = ''
+  if annotations and next(annotations) then
+    annot_param = string.format(', annotations: %s, block-id: %d',
+      code_annotations.annotations_to_typst_dict(annotations), block_id)
+  end
+
+  local lines_param = ''
+  if lines_label and lines_label ~= '' then
+    lines_param = string.format(', lines-label: "%s"', typst_escape_string(lines_label))
+  end
+
+  return pandoc.RawBlock('typst', string.format(
+    '#%s(filename: "%s", is-auto: %s, style: "%s"%s%s%s)[',
+    CONFIG.typst_wrapper,
+    typst_escape_string(filename),
+    is_auto and 'true' or 'false',
+    style,
+    annot_param,
+    typst_bg_colour_param(),
+    lines_param
+  ))
+end
+
+--- Build a standalone annotation wrapper for non-windowed blocks.
+--- @param annotations table
+--- @param block_id integer
+--- @return pandoc.RawBlock opening, pandoc.RawBlock closing
+local function typst_annotation_wrapper(annotations, block_id)
+  local open = pandoc.RawBlock('typst', string.format(
+    '#%s-annotated-content(annotations: %s, block-id: %d%s)[',
+    CONFIG.typst_wrapper,
+    code_annotations.annotations_to_typst_dict(annotations),
+    block_id,
+    typst_bg_colour_param()
+  ))
+  local close = pandoc.RawBlock('typst', ']')
+  return open, close
+end
+
+-- ============================================================================
+-- HTML PROCESSING
+-- ============================================================================
+
+--- Process CodeBlock for HTML/Reveal.js formats.
+--- Explicit-filename blocks are returned for Quarto to wrap; a marker class
+--- is added when a block-level style override is present.
+--- Auto-filename blocks are wrapped directly with the style class.
+--- @param block pandoc.CodeBlock Code block element
+--- @return pandoc.Div|pandoc.CodeBlock Wrapped block or original
+local function process_html(block)
+  -- Per-block opt-out: code-window-enabled="false" skips window chrome.
+  local block_enabled = block.attributes['code-window-enabled']
+  if block_enabled then
+    block.attributes['code-window-enabled'] = nil
+  end
+  if block_enabled == 'false' then
+    return block
+  end
+
+  local block_style = read_block_style(block)
+  local block_collapse = read_block_collapse(block)
+  local effective_collapse = block_collapse or CONFIG.collapse
+  local explicit_filename = block.attributes['filename']
+  local no_auto = block.attributes['code-window-no-auto-filename']
+  if no_auto then
+    block.attributes['code-window-no-auto-filename'] = nil
+  end
+
+  local lines_label = CONFIG.lines_label and read_block_lines_label(block) or nil
+
+  if explicit_filename and explicit_filename ~= '' then
+    -- Let Quarto create the .code-with-filename wrapper.
+    -- Add a marker class for block-level style override; the injected JS
+    -- reads it and promotes it to the wrapper div.
+    if block_style then
+      table.insert(block.classes, 'cw-style-' .. block_style)
+    end
+    if effective_collapse then
+      table.insert(block.classes, 'cw-collapse-' .. effective_collapse)
+    end
+    if lines_label then
+      block.attributes['code-window-lines-label'] = lines_label
+    end
+    return block
+  end
+
+  if not CONFIG.auto_filename or no_auto then
+    return block
+  end
+
+  local filename = block.classes[1]
+
+  -- Set the filename attribute so Quarto creates its own .code-with-filename
+  -- wrapper. This preserves the CodeBlock+OrderedList sibling structure
+  -- needed by Quarto's code-annotations processor.
+  block.attributes['filename'] = filename
+  table.insert(block.classes, 'cw-auto')
+  if block_style then
+    table.insert(block.classes, 'cw-style-' .. block_style)
+  end
+  if effective_collapse then
+    table.insert(block.classes, 'cw-collapse-' .. effective_collapse)
+  end
+  if lines_label then
+    block.attributes['code-window-lines-label'] = lines_label
+  end
+
+  return block
+end
+
+-- ============================================================================
+-- FILTER HANDLERS
+-- ============================================================================
+
+--- Generate a JS snippet that builds .code-with-filename wrappers for
+--- auto-filename blocks (marked with cw-auto at pre-quarto), applies the
+--- configured default style class to all .code-with-filename wrappers,
+--- promotes block-level cw-style-* / cw-collapse-* marker classes, inserts
+--- a highlighted-lines chip when data-code-window-lines-label is set on the inner
+--- pre, and wraps collapsible windows in a <details> element where the
+--- title bar acts as the <summary>.
+--- @param default_style string The configured default style
+--- @param default_collapse string|nil Default collapse mode ("open"/"closed"/nil)
+--- @return string JavaScript code
+local function make_style_js(default_style, default_collapse)
+  local default_collapse_js = default_collapse and ('"' .. default_collapse .. '"') or 'null'
+  return string.format([=[
+document.addEventListener("DOMContentLoaded",function(){
+  var DEFAULT_COLLAPSE=%s;
+  document.querySelectorAll("pre.cw-auto").forEach(function(pre){
+    var fn=pre.closest("[data-filename]");
+    if(!fn)return;
+    var name=fn.getAttribute("data-filename");
+    if(!name)return;
+    var scaffold=pre.closest(".code-copy-outer-scaffold")||pre.closest(".sourceCode");
+    if(!scaffold)return;
+    var w=document.createElement("div");
+    w.className="code-with-filename code-window-auto";
+    var tb=document.createElement("div");
+    tb.className="code-with-filename-file";
+    var tp=document.createElement("pre");
+    var ts=document.createElement("strong");
+    ts.textContent=name;
+    tp.appendChild(ts);tb.appendChild(tp);
+    scaffold.parentNode.insertBefore(w,scaffold);
+    w.appendChild(tb);w.appendChild(scaffold);
+    pre.classList.remove("cw-auto");
+  });
+  function findMarkerSource(el){
+    return el.querySelector('pre[class*="cw-style-"],pre[class*="cw-collapse-"],pre[data-code-window-lines-label]')
+      ||el.querySelector('[class*="cw-style-"],[class*="cw-collapse-"],[data-code-window-lines-label]');
+  }
+  document.querySelectorAll(".code-with-filename").forEach(function(el){
+    var marker=findMarkerSource(el);
+    var styleApplied=/\bcode-window-(macos|windows|default)\b/.test(el.className);
+    if(!styleApplied){
+      var sm=marker&&marker.className.match(/cw-style-(\w+)/);
+      if(sm){el.classList.add("code-window-"+sm[1]);marker.classList.remove(sm[0]);}
+      else{el.classList.add("code-window-%s");}
+    }
+    var collapse=null;
+    if(marker){
+      var cm=marker.className.match(/cw-collapse-(open|closed)/);
+      if(cm){collapse=cm[1];marker.classList.remove(cm[0]);}
+    }
+    if(collapse===null&&DEFAULT_COLLAPSE){collapse=DEFAULT_COLLAPSE;}
+    if(marker&&marker.hasAttribute("data-code-window-lines-label")){
+      var spec=marker.getAttribute("data-code-window-lines-label");
+      marker.removeAttribute("data-code-window-lines-label");
+      var titleBar=el.querySelector(".code-with-filename-file");
+      if(titleBar&&!titleBar.querySelector(".code-with-filename-lines")){
+        var chip=document.createElement("span");
+        chip.className="code-with-filename-lines";
+        chip.textContent="L"+spec;
+        titleBar.appendChild(chip);
+      }
+    }
+    if(collapse&&!el.classList.contains("code-window-collapsible")){
+      var titleBar=el.querySelector(".code-with-filename-file");
+      if(titleBar){
+        var details=document.createElement("details");
+        details.className=el.className+" code-window-collapsible";
+        if(collapse==="open"){details.open=true;}
+        var summaryEl=document.createElement("summary");
+        summaryEl.className="code-with-filename-file";
+        while(titleBar.firstChild){summaryEl.appendChild(titleBar.firstChild);}
+        titleBar.parentNode.removeChild(titleBar);
+        details.appendChild(summaryEl);
+        while(el.firstChild){details.appendChild(el.firstChild);}
+        el.parentNode.replaceChild(details,el);
+      }
+    }
+  });
+});]=], default_collapse_js, default_style)
+end
+
+--- Load configuration and inject CSS/JS dependencies.
+function Meta(meta)
+  CURRENT_FORMAT = pdoc.get_quarto_format()
+  local opts = meta_mod.get_options({
+    extension = EXTENSION_NAME,
+    keys = { 'enabled', 'auto-filename', 'style', 'wrapper', 'collapse', 'lines-label' },
+    meta = meta,
+    defaults = DEFAULTS,
+  })
+
+  if not VALID_STYLES[opts['style']] then
+    log.log_warning(EXTENSION_NAME,
+      string.format('Unknown style "%s", falling back to "macos".', opts['style']))
+  end
+
+  local global_collapse = resolve_collapse(opts['collapse'])
+
+  -- Read code-annotations metadata (Quarto standard option).
+  local annot_meta = meta['code-annotations']
+  local annot_value = annot_meta and pandoc.utils.stringify(annot_meta) or ''
+  local annotations_enabled = annot_value ~= 'none' and annot_value ~= 'false'
+
+  -- Read hotfix sub-table from extensions.code-window.hotfix.
+  local ext_config = meta_mod.get_extension_config(meta, EXTENSION_NAME)
+  local hotfix_meta = ext_config and ext_config['hotfix'] or nil
+
+  -- Deprecation check for old flat skylighting-fix key.
+  if ext_config and ext_config['skylighting-fix'] ~= nil then
+    log.log_warning(EXTENSION_NAME,
+      '"skylighting-fix" is deprecated. Use "hotfix: { skylighting: true/false }" instead.')
+  end
+
+  -- Parse hotfix options with per-hotfix version-based auto-disable.
+  -- Each hotfix value can be:
+  --   boolean/string: true/false to enable/disable
+  --   map: { enabled: true/false, quarto-version: "x.y.z" }
+  local hotfix = {}
+  for key, default in pairs(HOTFIX_DEFAULTS) do
+    local entry = hotfix_meta and hotfix_meta[key]
+    if entry ~= nil and pandoc.utils.type(entry) == 'table' then
+      -- Map form: { enabled: bool, quarto-version: "x.y.z" }
+      local enabled = true
+      if entry['enabled'] ~= nil then
+        enabled = pandoc.utils.stringify(entry['enabled']) == 'true'
+      end
+      local ver = entry['quarto-version']
+      if ver then
+        ver = pandoc.utils.stringify(ver)
+        if ver ~= '' then
+          local ok, threshold = pcall(pandoc.types.Version, ver)
+          if ok and quarto.version >= threshold then
+            enabled = false
+          end
+        end
+      end
+      hotfix[key] = enabled
+    elseif entry ~= nil then
+      -- Simple boolean/string form
+      hotfix[key] = pandoc.utils.stringify(entry) == 'true'
+    else
+      hotfix[key] = default
+    end
+  end
+
+  CONFIG = {
+    enabled = opts['enabled'] == 'true',
+    auto_filename = opts['auto-filename'] == 'true',
+    style = VALID_STYLES[opts['style']] and opts['style'] or 'macos',
+    typst_wrapper = opts['wrapper'],
+    collapse = global_collapse,
+    lines_label = opts['lines-label'] == 'true',
+    hotfix_code_annotations = hotfix['code-annotations'],
+    hotfix_skylighting = hotfix['skylighting'],
+    hotfix_typst_title = hotfix['typst-title'],
+    code_annotations = annotations_enabled,
+  }
+
+  -- Store hotfix state in metadata so the post-quarto typst-title-fix filter
+  -- can read it (it runs as a separate filter and has no access to CONFIG).
+  if not meta['_code-window-hotfix'] then
+    meta['_code-window-hotfix'] = pandoc.MetaMap({})
+  end
+  meta['_code-window-hotfix']['typst-title'] = pandoc.MetaString(
+    CONFIG.enabled and hotfix['typst-title'] and 'true' or 'false'
+  )
+
+  -- Cache syntax highlighting background colour for Typst contrast-aware annotations.
+  if CURRENT_FORMAT == 'typst' then
+    local hm = PANDOC_WRITER_OPTIONS and PANDOC_WRITER_OPTIONS.highlight_method
+    if hm then
+      local bg = hm['background-color']
+      if bg and type(bg) == 'string' then
+        TYPST_BG_COLOUR = bg
+      end
+    end
+  end
+
+  if CURRENT_FORMAT == 'html' and CONFIG.enabled then
+    html_mod.ensure_html_dependency({
+      name = EXTENSION_NAME,
+      version = '0.1.0',
+      stylesheets = { 'style.css' },
+    })
+    html_mod.ensure_html_dependency({
+      name = EXTENSION_NAME .. '-style-init',
+      version = '0.1.0',
+      head = '<script>' .. make_style_js(CONFIG.style, CONFIG.collapse) .. '</script>',
+    })
+  end
+
+  return meta
+end
+
+--- Process CodeBlock elements for HTML/Reveal.js only.
+--- Typst processing is handled by the Blocks filter.
+function CodeBlock(block)
+  if not CURRENT_FORMAT or not CONFIG or not CONFIG.enabled then
+    block.attributes['code-window-no-auto-filename'] = nil
+    return block
+  end
+
+  if CURRENT_FORMAT == 'html' then
+    return process_html(block)
+  end
+
+  return block
+end
+
+-- ============================================================================
+-- TYPST BLOCKS FILTER
+-- ============================================================================
+
+--- Determine whether a CodeBlock should get code-window chrome.
+--- @param block pandoc.CodeBlock
+--- @return string|nil filename
+--- @return boolean is_auto
+--- @return string|nil block_style
+--- @return boolean window_opted_out True when code-window-enabled="false" was set
+--- @return string|nil lines_label Highlighted-lines spec for the title bar
+local function resolve_window_params(block)
+  -- Per-block opt-out: code-window-enabled="false" skips window chrome.
+  local block_enabled = block.attributes['code-window-enabled']
+  if block_enabled then
+    block.attributes['code-window-enabled'] = nil
+  end
+  if block_enabled == 'false' then
+    return nil, false, nil, true, nil
+  end
+
+  local block_style = read_block_style(block)
+  local explicit_filename = block.attributes['filename']
+  local filename = explicit_filename
+  local is_auto = false
+  local no_auto = block.attributes['code-window-no-auto-filename']
+  if no_auto then
+    block.attributes['code-window-no-auto-filename'] = nil
+  end
+
+  if (not filename or filename == '') and not no_auto then
+    if CONFIG.auto_filename and block.classes and #block.classes > 0 then
+      filename = block.classes[1]
+      is_auto = true
+    end
+  end
+
+  local lines_label = nil
+  if CONFIG.lines_label then
+    lines_label = read_block_lines_label(block)
+  end
+
+  return filename, is_auto, block_style, false, lines_label
+end
+
+--- Process a single CodeBlock for Typst, returning replacement blocks.
+--- Handles both code-window wrapping and standalone annotation rendering.
+--- @param block pandoc.CodeBlock
+--- @param next_block pandoc.Block|nil The block following this CodeBlock
+--- @return pandoc.List replacement_blocks Blocks to splice in
+--- @return boolean consumed_next Whether the next block was consumed
+--- @return integer|nil annotation_block_id Block ID if annotations were found (for parent propagation)
+local function process_typst_block(block, next_block)
+  local filename, is_auto, block_style, window_opted_out, lines_label = resolve_window_params(block)
+  local has_window = filename and filename ~= ''
+  local effective_style = block_style or CONFIG.style
+
+  -- Resolve annotations if enabled and the code-annotations hot-fix is active.
+  local annotations = nil
+  local should_handle_annotations = CONFIG.code_annotations and CONFIG.hotfix_code_annotations
+
+  if should_handle_annotations then
+    local cleaned_text
+    cleaned_text, annotations = code_annotations.resolve_annotations(block)
+    if annotations then
+      block.text = cleaned_text
+    end
+  end
+
+  -- Strip filename attribute so the CodeBlock renders as plain code inside the
+  -- code-window wrapper (the DecoratedCodeBlock Div is already unwrapped above).
+  if has_window and block.attributes['filename'] then
+    block.attributes['filename'] = nil
+  end
+
+  local has_annotations = annotations and next(annotations)
+  local consumed_next = false
+  local result = {}
+  local block_id = has_annotations and next_block_id() or 0
+
+  if has_window and has_annotations then
+    table.insert(result, typst_code_window_open(
+      filename, is_auto, effective_style, annotations, block_id, lines_label))
+    table.insert(result, block)
+    table.insert(result, pandoc.RawBlock('typst', ']'))
+  elseif has_window then
+    table.insert(result, typst_code_window_open(
+      filename, is_auto, effective_style, nil, 0, lines_label))
+    table.insert(result, block)
+    table.insert(result, pandoc.RawBlock('typst', ']'))
+  elseif has_annotations then
+    local open, close = typst_annotation_wrapper(annotations, block_id)
+    table.insert(result, open)
+    table.insert(result, block)
+    table.insert(result, close)
+  else
+    table.insert(result, block)
+  end
+
+  -- Consume the following OrderedList if it is an annotation list.
+  if has_annotations
+      and next_block
+      and code_annotations.is_annotation_ordered_list(next_block) then
+    local wrapper_prefix = CONFIG.typst_wrapper
+    local annot_blocks = code_annotations.ordered_list_to_typst_blocks(
+      next_block, wrapper_prefix, block_id)
+    for _, ab in ipairs(annot_blocks) do
+      table.insert(result, ab)
+    end
+    consumed_next = true
+  end
+
+  local returned_block_id = has_annotations and (not consumed_next) and block_id or nil
+  return result, consumed_next, returned_block_id
+end
+
+--- Check if a Div is Quarto's DecoratedCodeBlock wrapper.
+--- @param div pandoc.Div
+--- @return boolean
+local function is_decorated_codeblock(div)
+  return div.attributes['__quarto_custom_type'] == 'DecoratedCodeBlock'
+end
+
+--- Extract the CodeBlock from a DecoratedCodeBlock Div.
+--- Structure: DecoratedCodeBlock Div > scaffold Div > CodeBlock
+--- @param div pandoc.Div
+--- @return pandoc.CodeBlock|nil
+local function extract_codeblock(div)
+  for _, child in ipairs(div.content) do
+    if child.t == 'CodeBlock' then
+      return child
+    elseif child.t == 'Div' then
+      local found = extract_codeblock(child)
+      if found then return found end
+    end
+  end
+  return nil
+end
+
+--- Read the filename from Quarto's internal custom node registry for a
+--- DecoratedCodeBlock Div. Quarto stores the #| filename: value there rather
+--- than as a plain Pandoc attribute on the inner CodeBlock.
+--- @param div pandoc.Div A DecoratedCodeBlock Div
+--- @return string|nil filename, or nil when the data is unavailable
+local function get_decorated_codeblock_filename(div)
+  local custom_id = div.attributes['__quarto_custom_id']
+  if not custom_id then return nil end
+  if not (_quarto and _quarto.ast and _quarto.ast.custom_node_data) then return nil end
+  local entry = _quarto.ast.custom_node_data[custom_id]
+  if type(entry) == 'table' and entry.filename and entry.filename ~= '' then
+    return entry.filename
+  end
+  return nil
+end
+
+--- Process a flat list of blocks for Typst, handling CodeBlocks and their
+--- following OrderedLists. Called recursively on Div contents.
+--- @param blocks pandoc.Blocks|pandoc.List
+--- @return pandoc.Blocks processed_blocks
+--- @return integer|nil pending_annotation_block_id Block ID if the last block had annotations (for parent consumption)
+local function process_typst_blocks(blocks, wrap_codeblocks)
+  local new_blocks = {}
+  local pending_annot_block_id = nil
+  local i = 1
+  while i <= #blocks do
+    local blk = blocks[i]
+
+    if blk.t == 'CodeBlock' then
+      local next_blk = blocks[i + 1]
+      local replacement, consumed_next, annot_id = process_typst_block(blk, next_blk)
+      local to_insert = (wrap_codeblocks and #replacement > 1)
+        and { pandoc.Div(replacement) } or replacement
+      for _, rb in ipairs(to_insert) do
+        table.insert(new_blocks, rb)
+      end
+      if consumed_next then
+        pending_annot_block_id = nil
+        i = i + 2
+      else
+        pending_annot_block_id = annot_id
+        i = i + 1
+      end
+    elseif blk.t == 'Div' and is_decorated_codeblock(blk) then
+      -- Unwrap Quarto's DecoratedCodeBlock to prevent double filename wrapping.
+      -- Process the inner CodeBlock directly, replacing the entire Div.
+      local inner_block = extract_codeblock(blk)
+      if inner_block then
+        -- Quarto stores the #| filename: value in its custom node registry, not as
+        -- a plain Pandoc attribute on the inner CodeBlock. Transfer it here so
+        -- resolve_window_params sees the explicit filename instead of falling back
+        -- to auto-filename.
+        if str.is_empty(inner_block.attributes['filename']) then
+          local fn = get_decorated_codeblock_filename(blk)
+          if fn then
+            inner_block.attributes['filename'] = fn
+          end
+        end
+        local next_blk = blocks[i + 1]
+        local replacement, consumed_next, annot_id = process_typst_block(inner_block, next_blk)
+        local to_insert = (wrap_codeblocks and #replacement > 1)
+          and { pandoc.Div(replacement) } or replacement
+        for _, rb in ipairs(to_insert) do
+          table.insert(new_blocks, rb)
+        end
+        if consumed_next then
+          pending_annot_block_id = nil
+          i = i + 2
+        else
+          pending_annot_block_id = annot_id
+          i = i + 1
+        end
+      else
+        -- Fallback: keep the Div as-is if no CodeBlock found.
+        local processed, inner_pending = process_typst_blocks(blk.content)
+        blk.content = processed
+        table.insert(new_blocks, blk)
+        pending_annot_block_id = inner_pending
+        i = i + 1
+      end
+    elseif blk.t == 'Div' then
+      local is_layout = blk.attributes['layout-ncol']
+        or blk.attributes['layout-nrow']
+        or blk.attributes['layout']
+      local processed, inner_pending = process_typst_blocks(blk.content, is_layout)
+      blk.content = processed
+      table.insert(new_blocks, blk)
+      -- If the Div's last processed block had pending annotations,
+      -- check if the next sibling is an OrderedList to consume.
+      if inner_pending then
+        local next_blk = blocks[i + 1]
+        if next_blk and code_annotations.is_annotation_ordered_list(next_blk) then
+          local annot_blocks = code_annotations.ordered_list_to_typst_blocks(
+            next_blk, CONFIG.typst_wrapper, inner_pending)
+          for _, ab in ipairs(annot_blocks) do
+            table.insert(new_blocks, ab)
+          end
+          pending_annot_block_id = nil
+          i = i + 2
+        else
+          pending_annot_block_id = inner_pending
+          i = i + 1
+        end
+      else
+        pending_annot_block_id = nil
+        i = i + 1
+      end
+    elseif blk.t == 'BulletList' or blk.t == 'OrderedList' then
+      for j, item in ipairs(blk.content) do
+        blk.content[j] = process_typst_blocks(pandoc.Blocks(item))
+      end
+      table.insert(new_blocks, blk)
+      pending_annot_block_id = nil
+      i = i + 1
+    elseif blk.t == 'BlockQuote' then
+      blk.content = process_typst_blocks(blk.content)
+      table.insert(new_blocks, blk)
+      pending_annot_block_id = nil
+      i = i + 1
+    elseif blk.t == 'DefinitionList' then
+      for j, def_item in ipairs(blk.content) do
+        for k, body in ipairs(def_item[2]) do
+          def_item[2][k] = process_typst_blocks(pandoc.Blocks(body))
+        end
+      end
+      table.insert(new_blocks, blk)
+      pending_annot_block_id = nil
+      i = i + 1
+    else
+      pending_annot_block_id = nil
+      table.insert(new_blocks, blk)
+      i = i + 1
+    end
+  end
+  return pandoc.Blocks(new_blocks), pending_annot_block_id
+end
+
+--- Walk HTML document blocks and transfer the filename from any DecoratedCodeBlock
+--- outer Div to its inner CodeBlock, so process_html sees an explicit filename
+--- and does not trigger auto-filename (which would otherwise produce a second
+--- .code-with-filename wrapper alongside Quarto's own).
+--- @param blocks pandoc.Blocks
+--- @return pandoc.Blocks
+local function fix_html_decorated_filenames(blocks)
+  return blocks:walk({
+    Div = function(div)
+      if not is_decorated_codeblock(div) then return nil end
+      local fn = get_decorated_codeblock_filename(div)
+      if not fn then return nil end
+      local inner_block = extract_codeblock(div)
+      if inner_block and str.is_empty(inner_block.attributes['filename']) then
+        inner_block.attributes['filename'] = fn
+      end
+      return div
+    end
+  })
+end
+
+--- Inject Typst function definition and process code blocks for Typst format.
+--- Also repairs HTML DecoratedCodeBlock filename propagation.
+--- Runs as a Pandoc filter to have full control over the document tree.
+function Pandoc(doc)
+  if not CONFIG or not CONFIG.enabled then
+    return doc
+  end
+
+  -- For HTML: transfer filenames from DecoratedCodeBlock Divs to inner
+  -- CodeBlocks before the CodeBlock filter runs, preventing auto-filename
+  -- from adding a second .code-with-filename wrapper.
+  if CURRENT_FORMAT == 'html' then
+    doc.blocks = fix_html_decorated_filenames(doc.blocks)
+    return doc
+  end
+
+  if CURRENT_FORMAT ~= 'typst' then
+    return doc
+  end
+
+  -- Process code blocks and annotations throughout the document tree.
+  doc.blocks = process_typst_blocks(doc.blocks)
+
+  -- Guard: check if the function definition is already present.
+  local fn_pattern = '#let ' .. CONFIG.typst_wrapper
+  for _, blk in ipairs(doc.blocks) do
+    if blk.t == 'RawBlock' and blk.format == 'typst'
+        and blk.text:find(fn_pattern, 1, true) then
+      return doc
+    end
+  end
+
+  local has_hotfixes = CONFIG.hotfix_code_annotations or CONFIG.hotfix_skylighting
+  local fn_def = build_typst_function_def(has_hotfixes)
+  if CONFIG.typst_wrapper ~= 'code-window' then
+    fn_def = fn_def:gsub('code%-window%-annote%-colour', CONFIG.typst_wrapper .. '-annote-colour')
+    fn_def = fn_def:gsub('code%-window%-circled%-number', CONFIG.typst_wrapper .. '-circled-number')
+    fn_def = fn_def:gsub('code%-window%-annotation%-item', CONFIG.typst_wrapper .. '-annotation-item')
+    fn_def = fn_def:gsub('code%-window%-annotated%-content', CONFIG.typst_wrapper .. '-annotated-content')
+    fn_def = fn_def:gsub('#let code%-window%(', '#let ' .. CONFIG.typst_wrapper .. '(')
+  end
+  table.insert(doc.blocks, 1, pandoc.RawBlock('typst', fn_def))
+
+  return doc
+end
+
+-- ============================================================================
+-- MODULE EXPORTS
+-- ============================================================================
+
+--- Inject the code-annotations module dependency.
+--- Called by main.lua before any filter handlers run.
+--- @param mod table The code-annotations module
+local function set_code_annotations(mod)
+  code_annotations = mod
+end
+
+return {
+  set_code_annotations = set_code_annotations,
+  Meta = Meta,
+  Pandoc = Pandoc,
+  CodeBlock = CodeBlock,
+  CONFIG = function() return CONFIG end,
+}

--- a/_extensions/mcanouil/code-window/main.lua
+++ b/_extensions/mcanouil/code-window/main.lua
@@ -1,0 +1,78 @@
+--- @module main
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @brief Entry point for the code-window extension.
+--- Loads all submodules, wires dependencies, and assembles the filter list.
+
+local EXTENSION_NAME = 'code-window'
+local log = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lua$', ''))
+
+-- ============================================================================
+-- LOAD SUBMODULES
+-- ============================================================================
+
+local language = require(
+  quarto.utils.resolve_path('_modules/language.lua'):gsub('%.lua$', ''))
+
+local code_annotations = require(
+  quarto.utils.resolve_path('_modules/hotfix/code-annotations.lua'):gsub('%.lua$', ''))
+
+local code_window = require(
+  quarto.utils.resolve_path('code-window.lua'):gsub('%.lua$', ''))
+
+code_window.set_code_annotations(code_annotations)
+
+-- ============================================================================
+-- SKYLIGHTING HOT-FIX
+-- ============================================================================
+
+--- Load optional skylighting hot-fix module from sibling file.
+--- @return table Module table with .filters and .set_wrapper, or empty table
+local function load_skylighting_hotfix_module()
+  local ok, result = pcall(require,
+    quarto.utils.resolve_path('_modules/hotfix/skylighting-typst-fix.lua'):gsub('%.lua$', ''))
+  if not ok then
+    log.log_warning(EXTENSION_NAME,
+      'Failed to load optional skylighting hot-fix: ' .. tostring(result))
+    return {}
+  end
+  if type(result) ~= 'table' then
+    log.log_warning(EXTENSION_NAME,
+      'Skylighting hot-fix did not return a module table.')
+    return {}
+  end
+  return result
+end
+
+-- ============================================================================
+-- FILTER ASSEMBLY
+-- ============================================================================
+
+local filters = {
+  { CodeBlock = language.CodeBlock },
+  { Meta = code_window.Meta },
+  { Pandoc = code_window.Pandoc },
+  { CodeBlock = code_window.CodeBlock },
+}
+
+local skylighting_mod = load_skylighting_hotfix_module()
+
+for _, subfilter in ipairs(skylighting_mod.filters or {}) do
+  local wrapped = {}
+  for element_type, handler in pairs(subfilter) do
+    wrapped[element_type] = function(...)
+      local cfg = code_window.CONFIG()
+      if not cfg or not cfg.hotfix_skylighting then
+        return nil
+      end
+      if skylighting_mod.set_wrapper then
+        skylighting_mod.set_wrapper(cfg.typst_wrapper)
+      end
+      return handler(...)
+    end
+  end
+  table.insert(filters, wrapped)
+end
+
+return filters

--- a/_extensions/mcanouil/code-window/style.css
+++ b/_extensions/mcanouil/code-window/style.css
@@ -1,0 +1,195 @@
+/* Code Window Extension for Quarto
+ * Code block window decorations with multiple styles
+ * MIT License - Mickaël Canouil 2026
+ */
+
+/* ============================================================================
+ * Theming variables (override to customise window-button icons and chip)
+ * ========================================================================= */
+
+:root {
+  --code-window-macos-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='10'%3E%3Ccircle cx='5' cy='5' r='5' fill='%23ff5f56'/%3E%3Ccircle cx='20' cy='5' r='5' fill='%23ffbd2e'/%3E%3Ccircle cx='35' cy='5' r='5' fill='%2327c93f'/%3E%3C/svg%3E");
+  --code-window-windows-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='10' fill='none'%3E%3Cline x1='3' y1='5' x2='11' y2='5' stroke='%23888' stroke-width='1.5' stroke-linecap='round'/%3E%3Crect x='17' y='1' width='8' height='8' rx='1' stroke='%23888' stroke-width='1.5' fill='none'/%3E%3Cline x1='31' y1='1' x2='39' y2='9' stroke='%23888' stroke-width='1.5' stroke-linecap='round'/%3E%3Cline x1='39' y1='1' x2='31' y2='9' stroke='%23888' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
+  --code-window-macos-icon-width: 3.4em;
+  --code-window-windows-icon-width: 3.6em;
+  --code-window-icon-height: 0.85em;
+}
+
+/* ============================================================================
+ * Base container
+ * ========================================================================= */
+
+.code-with-filename {
+  margin: 1.5em 0;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, currentColor 15%, Canvas);
+  background-color: Canvas;
+  overflow: hidden;
+  page-break-inside: avoid;
+  break-inside: avoid;
+}
+
+/* Title bar (shared across all styles) */
+.code-with-filename .code-with-filename-file {
+  display: flex;
+  align-items: center;
+  gap: 0.75em;
+  background-color: color-mix(in srgb, currentColor 5%, Canvas);
+  border: none;
+  border-bottom: 1px solid color-mix(in srgb, currentColor 15%, Canvas);
+  border-radius: 0;
+  padding: 0.2em 1em;
+  line-height: 1.2;
+  margin: 0;
+  page-break-after: avoid;
+  break-after: avoid;
+}
+
+/* Shrink title bar ~35% on Reveal.js slides (scales padding, decorations, and filename text proportionally) */
+.reveal .code-with-filename .code-with-filename-file {
+  font-size: 0.65em;
+  padding: 0.3em 1em;
+}
+
+/* Filename styling (base) */
+.code-with-filename .code-with-filename-file pre {
+  flex: 1;
+  margin: 0;
+  padding: 0;
+  background-color: transparent;
+  border: none;
+  font-size: 0.85em;
+  font-weight: 500;
+  color: color-mix(in srgb, currentColor 50%, Canvas);
+}
+
+/* Highlighted-lines chip rendered next to the filename in the title bar */
+.code-with-filename .code-with-filename-file .code-with-filename-lines {
+  flex: 0 0 auto;
+  font-size: 0.7em;
+  font-weight: 500;
+  font-family: var(--bs-font-monospace, monospace);
+  color: color-mix(in srgb, currentColor 60%, Canvas);
+  background-color: color-mix(in srgb, currentColor 10%, Canvas);
+  border: 1px solid color-mix(in srgb, currentColor 15%, Canvas);
+  border-radius: 3px;
+  padding: 0.05em 0.4em;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+/* Code block content area */
+.code-with-filename .sourceCode,
+.code-with-filename div.sourceCode,
+.code-with-filename .code-copy-outer-scaffold {
+  margin: 0;
+  border: none;
+  border-radius: 0;
+}
+
+.code-with-filename .sourceCode pre,
+.code-with-filename div.sourceCode pre,
+.code-with-filename .code-copy-outer-scaffold pre {
+  margin: 0;
+  border: none;
+  border-radius: 0;
+}
+
+/* Plain code blocks (unknown language without sourceCode wrapper) */
+.code-with-filename > pre {
+  margin: 0;
+  border: none;
+  border-radius: 0;
+}
+
+/* Auto-generated filenames display in simulated small caps */
+.code-with-filename.code-window-auto .code-with-filename-file pre strong {
+  text-transform: uppercase;
+  font-size: 0.8em;
+}
+
+/* Code block bottom border-radius */
+.code-with-filename .code-copy-outer-scaffold {
+  border-radius: 0 0 8px 8px;
+  overflow: hidden;
+}
+
+/* ============================================================================
+ * Style: default (plain filename, no decorations)
+ * ========================================================================= */
+
+.code-with-filename.code-window-default .code-with-filename-file pre {
+  text-align: left;
+}
+
+/* ============================================================================
+ * Style: macos (traffic lights left, filename right)
+ * ========================================================================= */
+
+.code-with-filename.code-window-macos .code-with-filename-file::before {
+  content: '';
+  display: inline-flex;
+  flex-shrink: 0;
+  width: var(--code-window-macos-icon-width);
+  height: var(--code-window-icon-height);
+  background-image: var(--code-window-macos-icon);
+  background-size: contain;
+  background-repeat: no-repeat;
+}
+
+.code-with-filename.code-window-macos .code-with-filename-file pre {
+  text-align: right;
+}
+
+/* ============================================================================
+ * Style: windows (filename left, window buttons right)
+ * ========================================================================= */
+
+.code-with-filename.code-window-windows .code-with-filename-file pre {
+  text-align: left;
+}
+
+.code-with-filename.code-window-windows .code-with-filename-file::after {
+  content: '';
+  display: inline-flex;
+  flex-shrink: 0;
+  width: var(--code-window-windows-icon-width);
+  height: var(--code-window-icon-height);
+  background-image: var(--code-window-windows-icon);
+  background-position: right;
+  background-size: contain;
+  background-repeat: no-repeat;
+}
+
+/* ============================================================================
+ * Collapsible code window (<details>)
+ * ========================================================================= */
+
+.code-with-filename.code-window-collapsible {
+  padding: 0;
+}
+
+.code-with-filename.code-window-collapsible > summary.code-with-filename-file {
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+
+.code-with-filename.code-window-collapsible > summary.code-with-filename-file::-webkit-details-marker {
+  display: none;
+}
+
+/* Bottom-border on summary only when expanded so the closed state has no
+ * separator line beneath an already-rounded container. */
+.code-with-filename.code-window-collapsible:not([open]) > summary.code-with-filename-file {
+  border-bottom: none;
+}
+
+/* Round the title bar corners when the window is closed. */
+.code-with-filename.code-window-collapsible:not([open]) {
+  border-radius: 8px;
+}
+
+.code-with-filename.code-window-collapsible:not([open]) > summary.code-with-filename-file {
+  border-radius: 8px;
+}

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -24,6 +24,7 @@ project:
 
 filters:
   - social-share
+  - code-window
 
 website:
   title: "Noah Weidig"

--- a/assets/theme-dark.scss
+++ b/assets/theme-dark.scss
@@ -30,6 +30,11 @@ $input-bg: #13131a;
   --nw-glass-strong: rgba(10, 10, 15, 0.96);
   --nw-stat-number: #ffffff;
   --nw-navcta: #ffffff;
+  /* code-window extension: force a proper dark bg (default Canvas renders
+     light because the page never declares color-scheme: dark) */
+  --nw-code-bg: #14141b;
+  --nw-code-titlebar: #1b1b23;
+  --nw-code-border: #2a2a34;
 }
 
 /* solid mark renders black by default; flip to white on dark */

--- a/assets/theme-light.scss
+++ b/assets/theme-light.scss
@@ -29,6 +29,10 @@ $card-bg: #ffffff;
   --nw-glass-strong: rgba(255, 255, 255, 0.96);
   --nw-stat-number: #000000;
   --nw-navcta: #000000;
+  /* code-window extension: light but darker than the near-white default */
+  --nw-code-bg: #e8ebef;
+  --nw-code-titlebar: #dde1e7;
+  --nw-code-border: #cbd2da;
 }
 
 /* solid mark stays black on light */

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -1695,3 +1695,25 @@ body:has(.nw-cv) #title-block-header {
 .page-columns > .social-share {
   grid-column: screen-start / screen-end;
 }
+
+/* code-window extension theming. The extension paints itself from the CSS
+   system colors `Canvas`/`currentColor`, which track the browser color-scheme
+   rather than Quarto's light/dark toggle, so dark-mode windows render light and
+   the default gray is too pale. Pin the surfaces to theme-aware vars instead
+   (defined in theme-light.scss / theme-dark.scss). */
+.code-with-filename {
+  background-color: var(--nw-code-bg) !important;
+  border-color: var(--nw-code-border) !important;
+}
+
+.code-with-filename .code-with-filename-file {
+  background-color: var(--nw-code-titlebar) !important;
+  border-bottom-color: var(--nw-code-border) !important;
+}
+
+.code-with-filename .sourceCode pre,
+.code-with-filename div.sourceCode pre,
+.code-with-filename .code-copy-outer-scaffold pre,
+.code-with-filename > pre {
+  background-color: var(--nw-code-bg) !important;
+}

--- a/index.qmd
+++ b/index.qmd
@@ -89,13 +89,13 @@ include-after-body:
             nwMap.easeTo({
               center: [ORLANDO[0] + 55, 12],
               zoom: 1.6,
-              duration: 3000,
+              duration: 1800,
               easing: function (t) { return t; },
               essential: true
             });
             nwMap.once('moveend', function () {
               // …stage 2: finish the spin and dive down into Orlando.
-              nwMap.flyTo({ center: ORLANDO, zoom: 12.2, duration: 5200, essential: true });
+              nwMap.flyTo({ center: ORLANDO, zoom: 12.2, duration: 3000, essential: true });
               nwMap.once('moveend', nwShowMarker);
             });
           }


### PR DESCRIPTION
## What

- Installs the [mcanouil/quarto-code-window](https://github.com/mcanouil/quarto-code-window) extension (`_extensions/mcanouil/code-window`, v1.2.1) and enables its filter in `_quarto.yml`.
- Makes code-window backgrounds theme-aware so they respect Quarto's light/dark toggle.
- Speeds up the homepage map fly-in.

## Why

The extension paints its windows from the CSS system colors `Canvas` / `currentColor`. Those track the **browser** color-scheme, not Quarto's light/dark toggle — so dark-mode windows rendered light, and the default gray was too pale in both modes.

## How

- Added `--nw-code-bg`, `--nw-code-titlebar`, `--nw-code-border` vars in `assets/theme-light.scss` (a darker light gray) and `assets/theme-dark.scss` (a proper dark gray).
- Override the extension surfaces (container, title bar, code `pre`) to use those vars in `assets/theme.scss`.
- Shortened the map fly-in durations in `index.qmd` (stage 1 easeTo `3000 → 1800ms`, stage 2 flyTo `5200 → 3000ms`).

## Notes

No local Quarto in this environment, so the render wasn't run here — the site builds in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019euamyZosJ86Fm5PRd2XE5

---
_Generated by [Claude Code](https://claude.ai/code/session_019euamyZosJ86Fm5PRd2XE5)_