### PR TITLE
Add icon-tinted gradients to research cards and /interests detail pages

### DIFF
--- a/assets/theme-dark.scss
+++ b/assets/theme-dark.scss
@@ -18,6 +18,9 @@ $input-bg: #13131a;
   --nw-card: #13131a;
   --nw-border: #26262f;
   --nw-chip: #1d1d26;
+  /* strength of the icon-color wash on research-area cards */
+  --nw-tint: 12%;
+  --nw-tint-hover: 18%;
   --nw-hero-glow: rgba(0, 118, 223, 0.18);
   --nw-cta-from: #0076DF;
   --nw-cta-via: #0076DF;

--- a/assets/theme-light.scss
+++ b/assets/theme-light.scss
@@ -17,6 +17,9 @@ $card-bg: #ffffff;
   --nw-card: #ffffff;
   --nw-border: #e5e7eb;
   --nw-chip: #eef2f7;
+  /* strength of the icon-color wash on research-area cards */
+  --nw-tint: 7%;
+  --nw-tint-hover: 12%;
   --nw-hero-glow: rgba(0, 118, 223, 0.12);
   --nw-cta-from: #d7ebff;
   --nw-cta-via: #eaf5ff;

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -484,7 +484,18 @@ body {
   border: 1px solid var(--nw-border);
   border-radius: 1rem;
   padding: 1.75rem;
-  transition: transform 0.2s, border-color 0.2s, box-shadow 0.2s;
+  transition: transform 0.2s, border-color 0.2s, box-shadow 0.2s, background 0.2s;
+}
+
+/* research-area cards double as links to their /interests/ detail pages */
+a.nw-card {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+
+a.nw-card:hover h3 {
+  color: var(--nw-primary);
 }
 
 .nw-card:hover {
@@ -540,9 +551,36 @@ body {
 .g-emerald { background: linear-gradient(135deg, #34d399, #14b8a6); }
 .g-amber   { background: linear-gradient(135deg, #fbbf24, #f97316); }
 .g-sky     { background: linear-gradient(135deg, #38bdf8, #0076DF); }
-.g-fuchsia { background: linear-gradient(135deg, #38bdf8, #0076DF); }
+.g-fuchsia { background: linear-gradient(135deg, #e879f9, #a855f7); }
 .g-lime    { background: linear-gradient(135deg, #a3e635, #16a34a); }
 .g-rose    { background: linear-gradient(135deg, #fb7185, #ef4444); }
+
+/* Research-area cards: a subtle two-tone wash keyed to each card's icon
+   colors. The two hues are mixed into the card background by --nw-tint
+   (small in light, a touch stronger in dark) so the tint stays gentle in
+   both themes. Icon-color pairs mirror the .g-* tiles above. */
+.nw-card:has(.g-emerald) { --c1: #34d399; --c2: #14b8a6; }
+.nw-card:has(.g-amber)   { --c1: #fbbf24; --c2: #f97316; }
+.nw-card:has(.g-sky)     { --c1: #38bdf8; --c2: #0076DF; }
+.nw-card:has(.g-fuchsia) { --c1: #e879f9; --c2: #a855f7; }
+.nw-card:has(.g-lime)    { --c1: #a3e635; --c2: #16a34a; }
+.nw-card:has(.g-rose)    { --c1: #fb7185; --c2: #ef4444; }
+
+.nw-card:has(.nw-icon) {
+  background: linear-gradient(
+    145deg,
+    color-mix(in srgb, var(--c1) var(--nw-tint), var(--nw-card)),
+    color-mix(in srgb, var(--c2) var(--nw-tint), var(--nw-card))
+  );
+}
+
+.nw-card:has(.nw-icon):hover {
+  background: linear-gradient(
+    145deg,
+    color-mix(in srgb, var(--c1) var(--nw-tint-hover), var(--nw-card)),
+    color-mix(in srgb, var(--c2) var(--nw-tint-hover), var(--nw-card))
+  );
+}
 
 /* ============ project cards (listing) ============ */
 .nw-projects.quarto-listing {

--- a/index.qmd
+++ b/index.qmd
@@ -208,42 +208,42 @@ include-after-body:
     <p class="nw-subtitle">Where I focus my work</p>
     <p class="nw-lead">I work at the intersection of geospatial analytics, data science, and applied AI — turning spatial and environmental data into decision-ready insight.</p>
     <div class="nw-grid">
-      <div class="nw-card">
+      <a class="nw-card" href="interests/remote-sensing/">
         <span class="nw-icon g-emerald"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3.707 6.293l2.586 -2.586a1 1 0 0 1 1.414 0l5.586 5.586a1 1 0 0 1 0 1.414l-2.586 2.586a1 1 0 0 1 -1.414 0l-5.586 -5.586a1 1 0 0 1 0 -1.414z"/><path d="M6 10l-3 3l3 3l3 -3"/><path d="M10 6l3 -3l3 3l-3 3"/><path d="M12 12l1.5 1.5"/><path d="M14.5 17a2.5 2.5 0 0 0 2.5 -2.5"/><path d="M15 21a6 6 0 0 0 6 -6"/></svg></span>
         <h3>Remote Sensing &amp; Earth Observation</h3>
         <p>Extracting signal from satellite and aerial imagery to monitor landscapes, vegetation, and environmental change over time.</p>
         <div class="nw-chips"><span class="nw-chip">Imagery Analysis</span><span class="nw-chip">Google Earth Engine</span><span class="nw-chip">Change Detection</span></div>
-      </div>
-      <div class="nw-card">
+      </a>
+      <a class="nw-card" href="interests/land-use-change/">
         <span class="nw-icon g-amber"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7l6 -3l6 3l6 -3v13l-6 3l-6 -3l-6 3z"/><path d="M9 4v13"/><path d="M15 7v13"/></svg></span>
         <h3>Land-Use Change &amp; Social-Ecological Systems</h3>
         <p>Studying how landscapes and communities co-evolve — wildland-urban interface, land management, and regional risk.</p>
         <div class="nw-chips"><span class="nw-chip">Land-Use Change</span><span class="nw-chip">Wildfire &amp; WUI</span><span class="nw-chip">Risk Assessment</span></div>
-      </div>
-      <div class="nw-card">
+      </a>
+      <a class="nw-card" href="interests/spatial-data-science/">
         <span class="nw-icon g-sky"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 13a1 1 0 0 1 1 -1h2a1 1 0 0 1 1 1v6a1 1 0 0 1 -1 1h-2a1 1 0 0 1 -1 -1z"/><path d="M10 9a1 1 0 0 1 1 -1h2a1 1 0 0 1 1 1v10a1 1 0 0 1 -1 1h-2a1 1 0 0 1 -1 -1z"/><path d="M17 5a1 1 0 0 1 1 -1h2a1 1 0 0 1 1 1v14a1 1 0 0 1 -1 1h-2a1 1 0 0 1 -1 -1z"/></svg></span>
         <h3>Spatial Data Science &amp; Statistical Modeling</h3>
         <p>Building reproducible spatial workflows and statistical models that quantify pattern, uncertainty, and trend.</p>
         <div class="nw-chips"><span class="nw-chip">Bayesian Analysis</span><span class="nw-chip">Forecasting</span><span class="nw-chip">Reproducible Research</span></div>
-      </div>
-      <div class="nw-card">
+      </a>
+      <a class="nw-card" href="interests/applied-ai/">
         <span class="nw-icon g-fuchsia"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M16 18a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2z"/><path d="M16 6a2 2 0 0 1 2 2a2 2 0 0 1 2 -2a2 2 0 0 1 -2 -2a2 2 0 0 1 -2 2z"/><path d="M9 18a6 6 0 0 1 6 -6a6 6 0 0 1 -6 -6a6 6 0 0 1 -6 6a6 6 0 0 1 6 6z"/></svg></span>
         <h3>Applied AI &amp; Data Storytelling</h3>
         <p>Applying machine learning to geospatial problems and communicating results through clear, compelling visualization.</p>
         <div class="nw-chips"><span class="nw-chip">Machine Learning</span><span class="nw-chip">Data Visualization</span><span class="nw-chip">Quantitative Ecology</span></div>
-      </div>
-      <div class="nw-card">
+      </a>
+      <a class="nw-card" href="interests/biodiversity-conservation/">
         <span class="nw-icon g-lime"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 21c.5 -4.5 2.5 -8 7 -10"/><path d="M9 18c6.218 0 10.5 -3.288 11 -12v-2h-4.014c-9 0 -11.986 4 -12 9c0 1 0 3 2 5h3z"/></svg></span>
         <h3>Biodiversity &amp; Conservation Monitoring</h3>
         <p>Tracking species, habitats, and ecosystem health to inform conservation planning and management decisions.</p>
         <div class="nw-chips"><span class="nw-chip">Species Distribution</span><span class="nw-chip">Habitat Mapping</span><span class="nw-chip">Conservation Planning</span></div>
-      </div>
-      <div class="nw-card">
+      </a>
+      <a class="nw-card" href="interests/geospatial-engineering/">
         <span class="nw-icon g-rose"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="6" rx="8" ry="3"/><path d="M4 6v6a8 3 0 0 0 16 0v-6"/><path d="M4 12v6a8 3 0 0 0 16 0v-6"/></svg></span>
         <h3>Geospatial Engineering &amp; Open Data</h3>
         <p>Designing scalable spatial data pipelines and open, interoperable tools that make geospatial work reproducible and shareable.</p>
         <div class="nw-chips"><span class="nw-chip">Spatial Databases</span><span class="nw-chip">Data Pipelines</span><span class="nw-chip">Open Source GIS</span></div>
-      </div>
+      </a>
     </div>
   </div>
 </section>

--- a/interests/_metadata.yml
+++ b/interests/_metadata.yml
@@ -1,0 +1,11 @@
+# Social share buttons (schochastics/quarto-social-share). Applied to every
+# page in this directory; the site home page and 404 are intentionally excluded.
+share:
+  # Fallback only; assets/social-share.js rewrites this to the live page URL.
+  permalink: "https://noahweidig.com/"
+  twitter: true
+  linkedin: true
+  bsky: true
+  reddit: true
+  facebook: true
+  email: true

--- a/interests/applied-ai/index.qmd
+++ b/interests/applied-ai/index.qmd
@@ -1,0 +1,16 @@
+---
+title: "Applied AI & Data Storytelling"
+description: "Applying machine learning to geospatial problems and communicating results through clear, compelling visualization."
+date: "2025-01-01"
+categories: [Interest]
+---
+
+::: {.nw-detail-lead}
+Machine Learning · Data Visualization · Quantitative Ecology
+:::
+
+Machine learning is a powerful lever for geospatial problems — but only if the results are trustworthy and someone can actually understand them. I sit at both ends of that pipeline: training models that solve real spatial tasks, and translating their output into something a decision-maker can read at a glance.
+
+On the modeling side, I apply supervised and unsupervised learning to imagery classification, species and habitat prediction, and pattern discovery in large environmental datasets — always paying attention to validation, class balance, and where a model is likely to fail. On the communication side, I design visualizations and maps that carry the finding, not just the data: clear encodings, honest scales, and a narrative that leads the audience to the point.
+
+Good data storytelling closes the loop between analysis and action. A model that no one understands changes nothing.

--- a/interests/biodiversity-conservation/index.qmd
+++ b/interests/biodiversity-conservation/index.qmd
@@ -1,0 +1,16 @@
+---
+title: "Biodiversity & Conservation Monitoring"
+description: "Tracking species, habitats, and ecosystem health to inform conservation planning and management decisions."
+date: "2025-01-01"
+categories: [Interest]
+---
+
+::: {.nw-detail-lead}
+Species Distribution · Habitat Mapping · Conservation Planning
+:::
+
+Conservation runs on evidence: you cannot protect what you have not measured. My work here uses spatial and ecological data to track where species live, how their habitats are faring, and where limited conservation effort will do the most good.
+
+That includes building species-distribution models that link occurrence records to environmental drivers, mapping and monitoring habitat condition through time, and framing the results as concrete planning inputs — priority areas, connectivity corridors, and management targets. Grounded in a background in ecology, I try to keep the biology in the loop, so a model reflects how organisms actually use a landscape rather than just where the pixels happen to correlate.
+
+The through-line is turning scattered observations into a coherent, spatial picture of ecosystem health that managers can act on before options close.

--- a/interests/geospatial-engineering/index.qmd
+++ b/interests/geospatial-engineering/index.qmd
@@ -1,0 +1,16 @@
+---
+title: "Geospatial Engineering & Open Data"
+description: "Scalable spatial data pipelines and open, interoperable tools that make geospatial work reproducible and shareable."
+date: "2025-01-01"
+categories: [Interest]
+---
+
+::: {.nw-detail-lead}
+Spatial Databases · Data Pipelines · Open Source GIS
+:::
+
+Behind every good map is infrastructure — the databases, pipelines, and formats that move data from raw source to finished analysis without losing its integrity. Geospatial engineering is the part of my work that makes everything else repeatable at scale.
+
+I design spatial data pipelines that ingest, clean, and standardize large heterogeneous datasets, backed by spatial databases (PostGIS and friends) and built on open, interoperable formats like GeoParquet, Cloud-Optimized GeoTIFF, and STAC. I lean heavily on the open-source GIS stack — GDAL, QGIS, Python and R geospatial libraries — because open tools and open data are what let others verify, reuse, and build on the work.
+
+The aim is durable plumbing: systems that a collaborator can pick up, understand, and extend long after the original analysis is done.

--- a/interests/land-use-change/index.qmd
+++ b/interests/land-use-change/index.qmd
@@ -1,0 +1,16 @@
+---
+title: "Land-Use Change & Social-Ecological Systems"
+description: "How landscapes and communities co-evolve — wildland-urban interface, land management, and regional risk."
+date: "2025-01-01"
+categories: [Interest]
+---
+
+::: {.nw-detail-lead}
+Land-Use Change · Wildfire & WUI · Risk Assessment
+:::
+
+Land use is where human decisions and ecological processes meet on the same map. I study how those two systems shape each other — how development, management, and policy rewrite the landscape, and how the landscape pushes back through fire, flood, and shifting habitat.
+
+Much of my recent work centers on the wildland-urban interface (WUI): the expanding edge where homes press into flammable vegetation. My M.S. thesis mapped large-wildfire patterns across the WUI of the eastern United States, quantifying how settlement geometry and fuel arrangement drive exposure and risk. That framing — treating people and ecosystems as one coupled system rather than two separate ones — carries into everything from land-management planning to regional risk assessment.
+
+Understanding these dynamics means combining historical land-cover records, demographic and parcel data, and disturbance histories into a single spatial narrative of change.

--- a/interests/remote-sensing/index.qmd
+++ b/interests/remote-sensing/index.qmd
@@ -1,0 +1,16 @@
+---
+title: "Remote Sensing & Earth Observation"
+description: "Extracting signal from satellite and aerial imagery to monitor landscapes, vegetation, and environmental change over time."
+date: "2025-01-01"
+categories: [Interest]
+---
+
+::: {.nw-detail-lead}
+Imagery Analysis · Google Earth Engine · Change Detection
+:::
+
+Satellites and aircraft record the Earth's surface at a cadence and scale no field campaign can match. My work in remote sensing turns that raw imagery into measurements — surface reflectance, spectral indices, and land-cover classes that describe how a landscape is changing and why.
+
+I work across the full processing chain: sourcing and calibrating multispectral and SAR scenes, correcting for atmosphere and terrain, deriving vegetation and moisture indices, and building classification and change-detection workflows that hold up across seasons and sensors. Cloud platforms like Google Earth Engine let me run these analyses over decades of archive and continental extents without moving a single tile off the server.
+
+The goal is always the same: replace a subjective impression of "the landscape looks different" with a defensible, repeatable number — burned area, canopy loss, urban expansion, or drought stress — that decision-makers can actually use.

--- a/interests/spatial-data-science/index.qmd
+++ b/interests/spatial-data-science/index.qmd
@@ -1,0 +1,16 @@
+---
+title: "Spatial Data Science & Statistical Modeling"
+description: "Reproducible spatial workflows and statistical models that quantify pattern, uncertainty, and trend."
+date: "2025-01-01"
+categories: [Interest]
+---
+
+::: {.nw-detail-lead}
+Bayesian Analysis · Forecasting · Reproducible Research
+:::
+
+Spatial data breaks most of the assumptions that classical statistics is built on — nearby places are correlated, sampling is uneven, and the answer often depends on scale. My work in spatial data science is about modeling those realities honestly rather than ignoring them.
+
+I build statistical and probabilistic models that quantify not just a point estimate but the uncertainty around it: hierarchical and Bayesian models for messy ecological data, spatial regression that accounts for autocorrelation, and forecasts that come with credible intervals instead of false precision. Every step lives in scripted, version-controlled pipelines so that a result can be reproduced, audited, and rerun as new data arrives.
+
+Reproducibility is not an afterthought here — it is the deliverable. A model is only as valuable as your ability to trust, re-run, and extend it.


### PR DESCRIPTION
## Summary

- Gave each **Research Areas** card a subtle two-color background gradient keyed to its icon-tile colors. The two hues are blended into the card background with `color-mix()`, controlled per-theme by a new `--nw-tint` / `--nw-tint-hover` variable so the wash stays gentle in light mode and slightly stronger (for equivalent visibility) in dark mode. Hover deepens the tint.
- Made the research cards clickable, linking to new detail pages under `/interests/`.
- Added six `/interests/*` pages (`remote-sensing`, `land-use-change`, `spatial-data-science`, `applied-ai`, `biodiversity-conservation`, `geospatial-engineering`), each with descriptive copy, following the existing detail-page pattern (front matter, `.nw-detail-lead`, shared `_metadata.yml` for social-share buttons).
- Fixed the `.g-fuchsia` icon tile, which duplicated the sky-blue gradient, to actually render fuchsia so the Applied AI card's icon and its new background wash match.

## Implementation notes

- Gradients use CSS `:has()` to attach each card's two colors based on its `.g-*` icon class, plus a shared `.nw-card:has(.nw-icon)` rule for the wash — no per-card markup changes beyond the `div` → `a` conversion.
- `a.nw-card` gets `color: inherit; text-decoration: none;` and a primary-colored heading on hover so the cards read as links without visual clutter.
- Light and dark are both covered via the theme-specific `--nw-tint*` values in `theme-light.scss` / `theme-dark.scss`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LddpGcNM1AxZRdhJUujvjQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LddpGcNM1AxZRdhJUujvjQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated pages for six research areas, including Applied AI, biodiversity, geospatial engineering, land-use change, remote sensing, and spatial data science.
  * Research area cards are now clickable and link directly to their corresponding pages.
  * Added social sharing options across research-area pages.

* **Style**
  * Improved card hover transitions and introduced subtle, theme-aware icon color washes for research area cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->