### PR TITLE
Widen desktop hero side margins

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -175,6 +175,13 @@ body {
   padding-bottom: 5rem;
 }
 
+/* desktop: larger side margins → narrower hero row brings text + portrait closer */
+@media (min-width: 992px) {
+  #hero .nw-hero-inner {
+    max-width: 56rem;
+  }
+}
+
 @media (max-width: 640px) {
   .nw-section {
     padding: 3.5rem 0;


### PR DESCRIPTION
## Summary
Increases the left and right margins of the `#hero` section on desktop so the hero text and portrait sit closer together.

## Change
- Added a `min-width: 992px` override in `assets/site.css` capping `.nw-hero-inner` at `56rem` (down from `66rem`). Since the row uses `justify-content: space-between`, the narrower container both enlarges the side gutters and pulls the text and image toward each other.

Mobile and tablet layouts are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0172JDN8UR6rNqqBMQ7uDAr9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved desktop layout by limiting the width of the hero content area on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->