### PR TITLE
Derive hero project count at render time; wire up blog category filter

### DIFF
--- a/_ejs/post-row.ejs
+++ b/_ejs/post-row.ejs
@@ -1,5 +1,5 @@
 <% for (const item of items) { %>
-<div class="nw-post">
+<div class="nw-post" data-cats="<%= (item.categories || []).join('|') %>">
 <h3><a href="<%- item.path %>"><%= item.title %></a></h3>
 <div class="nw-post-date"><%= item.date ? new Date(item.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' }) : '' %></div>
 <p><%= item.description || '' %></p>

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,9 +3,12 @@ project:
   output-dir: _site
   render:
     - "*.qmd"
-  # Regenerate per-page Open Graph SVG cards after every render
-  # (see scripts/generate-og.ts for how the cards are built).
-  post-render: scripts/generate-og.ts
+  # After every render: sync the hero "Featured Projects" stat with the
+  # projects that actually have `featured: true` (scripts/update-stats.ts),
+  # then regenerate per-page Open Graph SVG cards (scripts/generate-og.ts).
+  post-render:
+    - scripts/update-stats.ts
+    - scripts/generate-og.ts
   resources:
     - CNAME
     - robots.txt

--- a/blog/index.qmd
+++ b/blog/index.qmd
@@ -13,7 +13,12 @@ listing:
     title: "Noah Weidig — Blog"
     description: "Notes on science, data, maps, and the landscapes we live in."
     items: 20
+include-after-body:
+  - text: |
+      <script src="../assets/home.js"></script>
 ---
+
+<div class="nw-filters" data-nw-filter-for="all-posts"></div>
 
 ::: {#all-posts .nw-posts}
 :::

--- a/index.qmd
+++ b/index.qmd
@@ -197,7 +197,9 @@ include-after-body:
       <div class="nw-stat"><b>25+</b><span>Papers &amp; Talks</span></div>
       <div class="nw-stat"><b>8+</b><span>Years Research Experience</span></div>
       <div class="nw-stat"><b>20+</b><span>Tools Mastered</span></div>
-      <div class="nw-stat"><b>14</b><span>Featured Projects</span></div>
+      <!-- The number is a fallback: scripts/update-stats.ts rewrites it at render
+     time to the count of projects/*/index.qmd with `featured: true`. -->
+      <div class="nw-stat"><b data-nw-stat="featured-projects">17</b><span>Featured Projects</span></div>
     </div>
   </div>
 </section>

--- a/scripts/update-stats.ts
+++ b/scripts/update-stats.ts
@@ -1,0 +1,60 @@
+/**
+ * update-stats.ts — keep the landing-page hero stats honest.
+ *
+ * Runs as a Quarto post-render step (see `project.post-render` in
+ * _quarto.yml). Quarto executes it with its bundled Deno, so there are no
+ * dependencies to install; for local debugging it also runs under Node:
+ *
+ *   node --experimental-strip-types scripts/update-stats.ts
+ *
+ * It counts the project pages whose frontmatter sets `featured: true` and
+ * writes that number into the "Featured Projects" stat on the rendered home
+ * page (the <b data-nw-stat="featured-projects"> element in index.qmd). The
+ * number in the source is only a fallback — deriving it here at every render
+ * means the stat can't drift when projects are added or unfeatured.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const projectRoot = process.env.QUARTO_PROJECT_DIR ??
+  path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const outputDir = process.env.QUARTO_PROJECT_OUTPUT_DIR
+  ? path.resolve(projectRoot, process.env.QUARTO_PROJECT_OUTPUT_DIR)
+  : path.join(projectRoot, "_site");
+
+function frontmatter(file: string): string {
+  const src = fs.readFileSync(file, "utf8");
+  const m = src.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  return m ? m[1] : "";
+}
+
+function main(): void {
+  const projectsDir = path.join(projectRoot, "projects");
+  let featured = 0;
+  for (const entry of fs.readdirSync(projectsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const page = path.join(projectsDir, entry.name, "index.qmd");
+    if (fs.existsSync(page) && /^featured:\s*true\s*$/m.test(frontmatter(page))) {
+      featured++;
+    }
+  }
+
+  const home = path.join(outputDir, "index.html");
+  if (!fs.existsSync(home)) {
+    console.error(`[stats] rendered home page not found: ${home}`);
+    process.exit(1);
+  }
+  const html = fs.readFileSync(home, "utf8");
+  const re = /(<b data-nw-stat="featured-projects">)[^<]*(<\/b>)/;
+  if (!re.test(html)) {
+    console.error("[stats] featured-projects stat marker not found in index.html");
+    process.exit(1);
+  }
+  const out = html.replace(re, `$1${featured}$2`);
+  if (out !== html) fs.writeFileSync(home, out);
+  console.log(`[stats] featured projects: ${featured}`);
+}
+
+main();


### PR DESCRIPTION
Fixes #79, fixes #78.

## Hero "Featured Projects" stat (#79)

The count was hand-maintained (`<b>14</b>` while 17 projects have `featured: true`), so it drifted every time a project was added. It's now derived at render time:

- **`scripts/update-stats.ts`** (new) runs as a Quarto post-render step, alongside the existing `generate-og.ts`. It counts `projects/*/index.qmd` pages whose frontmatter sets `featured: true` and writes that number into the rendered `_site/index.html`.
- `index.qmd` marks the stat with `<b data-nw-stat="featured-projects">17</b>`; the `17` is only a source-side fallback — every build overwrites it with the live count, so it can never go stale again.
- `_quarto.yml` runs the new script before `generate-og.ts`. Like the OG script, it needs no dependencies (Quarto's bundled Deno) and also runs under `node --experimental-strip-types` for local debugging — verified locally: it reports 17 and rewrites a stale number in place.

A render-time count was chosen over a client-side fetch so the correct number is in the HTML itself (no JS dependency, no flash of the old value), and over Quarto `{{< var >}}` shortcodes since the stat lives inside a raw HTML block.

## Dead category tags on blog posts (#78)

`nw-nav.js` retargets title-block category tags on `/blog/…` pages to `/blog/#category=<cat>`, but the blog listing had no filter bar and never loaded `home.js`, so the links scrolled to the top of `/blog/` and did nothing. Fixed by matching the projects/publications setup:

- `blog/index.qmd` — added `<div class="nw-filters" data-nw-filter-for="all-posts">` and the `home.js` include.
- `_ejs/post-row.ejs` — post rows now carry `data-cats="<%= (item.categories || []).join('|') %>"` (same pattern as `citation.ejs` / `project-card.ejs`), which `home.js` uses both to build the filter buttons and to honor the `#category=` deep link.

Note: `awards` also appears in the `nw-nav.js` retarget regex, but award pages define no `categories:`, so no tags render there — nothing to fix. If award categories are ever added, `awards/index.qmd` would need the same filter-bar treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsfrYDbJeGZZELMLtzJAvY

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsfrYDbJeGZZELMLtzJAvY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added category-based filtering to the blog post listing.
  * Added category metadata to blog posts to support filtering.
  * Featured Projects count now updates automatically based on featured project content.

* **Bug Fixes**
  * Improved reliability of homepage statistics by synchronizing the displayed count during site rendering.
  * Open Graph cards continue to regenerate after statistics are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->