### PR TITLE
Stamp footer copyright year at render time; harden stripHtml sanitization

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -120,7 +120,7 @@ website:
       </div>
       </div>
       <div class="nw-footer-bottom">
-      <div>© 2026 Noah Weidig · Built with <a href="https://quarto.org" class="nw-quarto-credit"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="8"/><path d="M12 4V20"/><path d="M4 12H20"/></svg>Quarto</a>. All Rights Reserved.</div>
+      <div>© <span data-nw-copyright-year>2026</span> Noah Weidig · Built with <a href="https://quarto.org" class="nw-quarto-credit"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="8"/><path d="M12 4V20"/><path d="M4 12H20"/></svg>Quarto</a>. All Rights Reserved.</div>
       </div>
       </div>
 

--- a/scripts/update-pubs.js
+++ b/scripts/update-pubs.js
@@ -16,12 +16,14 @@ function stripHtml(html) {
   if (!html) return "";
   // Strip tags until the output stabilizes: a single pass can leave markup
   // behind (e.g. "<scr<b></b>ipt>" → "<script>"), which CodeQL flags as
-  // incomplete multi-character sanitization.
+  // incomplete multi-character sanitization. The optional ">" keeps the
+  // regex linear-time (no rescanning past unclosed "<") and drops dangling
+  // unterminated tags too.
   let text = String(html);
   let prev;
   do {
     prev = text;
-    text = text.replace(/<[^>]*>/g, "");
+    text = text.replace(/<[^>]*>?/g, "");
   } while (text !== prev);
   return text
     .replace(/&(amp|lt|gt|quot|#39|apos|nbsp);/g, (m) => ENTITIES[m] || m)

--- a/scripts/update-pubs.js
+++ b/scripts/update-pubs.js
@@ -14,8 +14,16 @@ const ENTITIES = { "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"', "&#39;
 
 function stripHtml(html) {
   if (!html) return "";
-  return String(html)
-    .replace(/<[^>]*>/g, "")
+  // Strip tags until the output stabilizes: a single pass can leave markup
+  // behind (e.g. "<scr<b></b>ipt>" → "<script>"), which CodeQL flags as
+  // incomplete multi-character sanitization.
+  let text = String(html);
+  let prev;
+  do {
+    prev = text;
+    text = text.replace(/<[^>]*>/g, "");
+  } while (text !== prev);
+  return text
     .replace(/&(amp|lt|gt|quot|#39|apos|nbsp);/g, (m) => ENTITIES[m] || m)
     .replace(/\s+/g, " ")
     .trim();

--- a/scripts/update-stats.ts
+++ b/scripts/update-stats.ts
@@ -12,6 +12,11 @@
  * page (the <b data-nw-stat="featured-projects"> element in index.qmd). The
  * number in the source is only a fallback — deriving it here at every render
  * means the stat can't drift when projects are added or unfeatured.
+ *
+ * It also stamps the current year into the footer copyright notice (the
+ * <span data-nw-copyright-year> element from _quarto.yml) on every rendered
+ * page, so the year rolls over automatically with each render instead of
+ * waiting for a manual bump every January.
  */
 
 import fs from "node:fs";
@@ -55,6 +60,31 @@ function main(): void {
   const out = html.replace(re, `$1${featured}$2`);
   if (out !== html) fs.writeFileSync(home, out);
   console.log(`[stats] featured projects: ${featured}`);
+
+  stampCopyrightYear(outputDir);
+}
+
+function* htmlFiles(dir: string): Generator<string> {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) yield* htmlFiles(full);
+    else if (entry.isFile() && entry.name.endsWith(".html")) yield full;
+  }
+}
+
+function stampCopyrightYear(dir: string): void {
+  const year = String(new Date().getFullYear());
+  const re = /(<span data-nw-copyright-year[^>]*>)[^<]*(<\/span>)/g;
+  let stamped = 0;
+  for (const file of htmlFiles(dir)) {
+    const html = fs.readFileSync(file, "utf8");
+    const out = html.replace(re, `$1${year}$2`);
+    if (out !== html) {
+      fs.writeFileSync(file, out);
+      stamped++;
+    }
+  }
+  console.log(`[stats] copyright year ${year} stamped on ${stamped} page(s)`);
 }
 
 main();


### PR DESCRIPTION
## Summary

- The footer copyright year in `_quarto.yml` was hand-maintained and would silently show last year every January. The year is now wrapped in a `<span data-nw-copyright-year>` marker, and the `scripts/update-stats.ts` post-render step rewrites it to the current year on every rendered HTML page — the same approach used for the featured-projects stat in #80. Since the site re-renders at least biweekly via the Zotero sync, the year rolls over automatically, and the correct value ends up in the static HTML with no client-side JS dependency.
- Fixed the CodeQL `js/incomplete-multi-character-sanitization` warning in `scripts/update-pubs.js`: `stripHtml` now loops its tag-stripping replace until the output stabilizes, so nested/split markup (e.g. `<scr<b></b>ipt>`) can't survive a single pass.

## Testing

- Ran `update-stats.ts` under Node against a mock output directory with stale `2024` years on two pages (one nested): both stamped to `2026`, featured-projects stat still updates.
- Exercised the new `stripHtml` on `<scr<b></b>ipt>alert(1)</scr<i></i>ipt>` plus entity/whitespace cases: no `<` survives and normal decoding/collapsing behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xXR4DD91p7WwbCV1BfXkF

---
_Generated by [Claude Code](https://claude.ai/code/session_018xXR4DD91p7WwbCV1BfXkF)_