### PR TITLE
Fix missing hero particle network

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -24,6 +24,9 @@ project:
     - "assets/fonts/**"
     - assets/nw-nav.js
     - assets/social-share.js
+    # Loaded dynamically from index.qmd's hero script, so Quarto's resource
+    # discovery can't see it — must be listed explicitly.
+    - assets/vendor/particles.min.js
 
 filters:
   - social-share

--- a/assets/site.css
+++ b/assets/site.css
@@ -165,6 +165,8 @@ body {
    canvas sits on top of it); the grid backdrop first appears at the stats
    section. */
 #hero {
+  /* anchor for the absolutely-positioned #nw-particles canvas */
+  position: relative;
   background:
     radial-gradient(60rem 30rem at 50% -10%, var(--nw-hero-glow), transparent 70%),
     var(--nw-bg);


### PR DESCRIPTION
## Problem

The hero's "neural network" particle background never shows up on the deployed site.

## Cause

`assets/vendor/particles.min.js` is loaded dynamically from the hero's inline script (`js.src = 'assets/vendor/particles.min.js'`), so Quarto's automatic resource discovery never sees it and never copies it into `_site`. The live site 404s on it (verified: `https://noahweidig.com/assets/vendor/particles.min.js` → 404), so `particlesJS` never runs.

Secondary issue: `#nw-particles` uses `position: absolute; inset: 0`, but `#hero` had no `position`, so the canvas would anchor to the page instead of the hero.

## Fix

- List `assets/vendor/particles.min.js` explicitly under `project.resources` in `_quarto.yml`.
- Add `position: relative` to `#hero` in `assets/site.css` so the canvas fills exactly the hero.

Verified in a headless-Chromium harness that the canvas is created and its bounding box matches the hero's exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLynoHFAtfHWZNgAzw5HMv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLynoHFAtfHWZNgAzw5HMv)_